### PR TITLE
Committing Fl and ny

### DIFF
--- a/fl/.terraform.lock.hcl
+++ b/fl/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.87.0"
+  hashes = [
+    "h1:2A5UZnERIQPA9PMmbdfgFNqbYjUxk10J7W6d5QcTCM4=",
+    "zh:017f237466875c919330b9e214fb33af14fffbff830d3755e8976d8fa3c963c2",
+    "zh:0776d1e60aa93c85ecbb01144aed2789c8e180bb0f1c811a0aba17ca7247b26c",
+    "zh:0dfa5c6cfb3724494fdc73f7d042515e88a20da8968959f48b3ec0b937bd8c8f",
+    "zh:1707a5ead36a7980cb3f83e8b69a67a14ae725bfc990ddfcc209b59400b57b04",
+    "zh:1c71f54fdd6adcbe547d6577dbb843d72a30fef0ab882d0afbeb8a7b348bc442",
+    "zh:3563c850a29790957ec3f4d3ba203bfa2e084ac7319035b3f43b91f818a2c9b4",
+    "zh:520bf6cef53785a92226651d5bebacbbf9314bdbc3211d0bf0903bce4e45149d",
+    "zh:56f9778575830f6e5c23462c2eccbf2c9afaddb00a69275fcfb33cd1a6d17f4d",
+    "zh:73e381cb0b1e76d471d7b0952f3d2a80350b507d15bda9b7041ea69077e3b5b5",
+    "zh:7da74b48f8fa088be758a92407980400cb4b039a8d9ba3c108907e4055e9ad6f",
+    "zh:8dacfa9623ba2e0197fe7db6faaaa0820a3b91fe00ba9e5d8a646340522bc8dd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c2ebd21d697e1a611fe201788dc9e1678949a088afc85d4589563bca484d835",
+    "zh:ac5d0bbf36f9a6cedbfb63993f6baf0aabdaf21c8d7fc3b1e69ba8cbf344b5f3",
+    "zh:c2329644179f78a0458b6cf2dd5eaadca4c610fc3577a1b50620544d92df13e8",
+  ]
+}

--- a/fl/backend.tf
+++ b/fl/backend.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "terraform-bucket-tlyle-dev"
+    key            = "terraform/fl-state.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-lock-table-dev"
+    encrypt        = true
+  }
+}

--- a/fl/main.tf
+++ b/fl/main.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "${var.environment}-vpc"
+  }
+}

--- a/fl/terraform.tfvars
+++ b/fl/terraform.tfvars
@@ -1,0 +1,2 @@
+environment = "fl"
+cidr_block = "10.0.1.0/24"

--- a/fl/variables.tf
+++ b/fl/variables.tf
@@ -1,0 +1,12 @@
+variable "environment" {  
+}
+variable "vpc_name" {
+  description = "Name of the VPC"
+  type        = string
+  default     = "vpc-ny"
+}
+variable "cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/23"
+}

--- a/ny/.terraform.lock.hcl
+++ b/ny/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.87.0"
+  hashes = [
+    "h1:2A5UZnERIQPA9PMmbdfgFNqbYjUxk10J7W6d5QcTCM4=",
+    "zh:017f237466875c919330b9e214fb33af14fffbff830d3755e8976d8fa3c963c2",
+    "zh:0776d1e60aa93c85ecbb01144aed2789c8e180bb0f1c811a0aba17ca7247b26c",
+    "zh:0dfa5c6cfb3724494fdc73f7d042515e88a20da8968959f48b3ec0b937bd8c8f",
+    "zh:1707a5ead36a7980cb3f83e8b69a67a14ae725bfc990ddfcc209b59400b57b04",
+    "zh:1c71f54fdd6adcbe547d6577dbb843d72a30fef0ab882d0afbeb8a7b348bc442",
+    "zh:3563c850a29790957ec3f4d3ba203bfa2e084ac7319035b3f43b91f818a2c9b4",
+    "zh:520bf6cef53785a92226651d5bebacbbf9314bdbc3211d0bf0903bce4e45149d",
+    "zh:56f9778575830f6e5c23462c2eccbf2c9afaddb00a69275fcfb33cd1a6d17f4d",
+    "zh:73e381cb0b1e76d471d7b0952f3d2a80350b507d15bda9b7041ea69077e3b5b5",
+    "zh:7da74b48f8fa088be758a92407980400cb4b039a8d9ba3c108907e4055e9ad6f",
+    "zh:8dacfa9623ba2e0197fe7db6faaaa0820a3b91fe00ba9e5d8a646340522bc8dd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c2ebd21d697e1a611fe201788dc9e1678949a088afc85d4589563bca484d835",
+    "zh:ac5d0bbf36f9a6cedbfb63993f6baf0aabdaf21c8d7fc3b1e69ba8cbf344b5f3",
+    "zh:c2329644179f78a0458b6cf2dd5eaadca4c610fc3577a1b50620544d92df13e8",
+  ]
+}

--- a/ny/backend.tf
+++ b/ny/backend.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "terraform-bucket-tlyle-dev"
+    key            = "terraform/ny-state.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-lock-table-dev"
+    encrypt        = true
+  }
+}

--- a/ny/main.tf
+++ b/ny/main.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "${var.environment}-vpc"
+  }
+}

--- a/ny/terraform.tfvars
+++ b/ny/terraform.tfvars
@@ -1,0 +1,2 @@
+environment = "ny"
+cidr_block = "10.0.0.0/23"

--- a/ny/variables.tf
+++ b/ny/variables.tf
@@ -1,0 +1,12 @@
+variable "environment" {  
+}
+variable "vpc_name" {
+  description = "Name of the VPC"
+  type        = string
+  default     = "vpc-ny"
+}
+variable "cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/23"
+}


### PR DESCRIPTION
PS C:\Users\Thomas Lyle\repos\aws_git_hub\aws_deployment\ny> terraform plan    
aws_vpc.main: Refreshing state... [id=vpc-0076d7b5481e83acd]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated 
with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_vpc.main must be replaced
-/+ resource "aws_vpc" "main" {
      ~ arn                                  = "arn:aws:ec2:us-east-1:073457122123:vpc/vpc-0076d7b5481e83acd" -> (known after apply)
      - assign_generated_ipv6_cidr_block     = false -> null
      ~ cidr_block                           = "10.0.0.0/23" -> "10.0.0.0/24" # forces replacement
      ~ default_network_acl_id               = "acl-08579dcbe805b756c" -> (known after apply)
      ~ default_route_table_id               = "rtb-0e6e08099c343e710" -> (known after apply)
      ~ default_security_group_id            = "sg-013636b4217568d08" -> (known after apply)
      ~ dhcp_options_id                      = "dopt-9feed8e5" -> (known after apply)
      ~ enable_network_address_usage_metrics = false -> (known after apply)
      ~ id                                   = "vpc-0076d7b5481e83acd" -> (known after apply)
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      - ipv6_netmask_length                  = 0 -> null
      ~ main_route_table_id                  = "rtb-0e6e08099c343e710" -> (known after apply)
      ~ owner_id                             = "073457122123" -> (known after apply)
        tags                                 = {
            "Name" = "ny-vpc"
        }
        # (5 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.