### PR TITLE
remove-vpc-ny

### DIFF
--- a/ny/main.tf
+++ b/ny/main.tf
@@ -1,8 +1,8 @@
-resource "aws_vpc" "main" {
-  cidr_block           = var.cidr_block
-  enable_dns_support   = true
-  enable_dns_hostnames = true
-  tags = {
-    Name = "${var.environment}-vpc"
-  }
-}
+# resource "aws_vpc" "main" {
+#   cidr_block           = var.cidr_block
+#   enable_dns_support   = true
+#   enable_dns_hostnames = true
+#   tags = {
+#     Name = "${var.environment}-vpc"
+#   }
+# }


### PR DESCRIPTION
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated 
with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_vpc.main will be destroyed
  # (because aws_vpc.main is not in configuration)
  - resource "aws_vpc" "main" {
      - arn                                  = "arn:aws:ec2:us-east-1:073457122123:vpc/vpc-0ea80ebaffc78faf6" -> null
      - assign_generated_ipv6_cidr_block     = false -> null
      - cidr_block                           = "10.0.0.0/24" -> null
      - default_network_acl_id               = "acl-045af37e72a3436e2" -> null
      - default_route_table_id               = "rtb-0b239a9bf656c1abc" -> null
      - default_security_group_id            = "sg-0c89f011d12644104" -> null
      - dhcp_options_id                      = "dopt-9feed8e5" -> null
      - enable_dns_hostnames                 = true -> null
      - enable_dns_support                   = true -> null
      - enable_network_address_usage_metrics = false -> null
      - id                                   = "vpc-0ea80ebaffc78faf6" -> null
      - instance_tenancy                     = "default" -> null
      - ipv6_netmask_length                  = 0 -> null
      - main_route_table_id                  = "rtb-0b239a9bf656c1abc" -> null
      - owner_id                             = "073457122123" -> null
      - tags                                 = {
          - "Name" = "ny-vpc"
        } -> null
      - tags_all                             = {
          - "Name" = "ny-vpc"
        } -> null
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 1 to destroy.
