### PR TITLE
delete fl vpc

### DIFF
--- a/fl/main.tf
+++ b/fl/main.tf
@@ -1,8 +1,8 @@
-resource "aws_vpc" "main" {
-  cidr_block           = var.cidr_block
-  enable_dns_support   = true
-  enable_dns_hostnames = true
-  tags = {
-    Name = "${var.environment}-vpc"
-  }
-}
+# resource "aws_vpc" "main" {
+#   cidr_block           = var.cidr_block
+#   enable_dns_support   = true
+#   enable_dns_hostnames = true
+#   tags = {
+#     Name = "${var.environment}-vpc"
+#   }
+# }


### PR DESCRIPTION
erraform will perform the following actions:

  # aws_vpc.main will be destroyed
  # (because aws_vpc.main is not in configuration)
  - resource "aws_vpc" "main" {
      - arn                                  = "arn:aws:ec2:us-east-1:073457122123:vpc/vpc-06be9e7844a72f5ad" -> null
      - assign_generated_ipv6_cidr_block     = false -> null
      - cidr_block                           = "10.0.1.0/24" -> null
      - default_network_acl_id               = "acl-0ce2ca33bf2e05293" -> null
      - default_route_table_id               = "rtb-0386d993fd7c56a12" -> null
      - default_security_group_id            = "sg-07310f7cd6f936a50" -> null
      - dhcp_options_id                      = "dopt-9feed8e5" -> null
      - enable_dns_hostnames                 = true -> null
      - enable_dns_support                   = true -> null
      - enable_network_address_usage_metrics = false -> null
      - id                                   = "vpc-06be9e7844a72f5ad" -> null
      - instance_tenancy                     = "default" -> null
      - ipv6_netmask_length                  = 0 -> null
      - main_route_table_id                  = "rtb-0386d993fd7c56a12" -> null
      - owner_id                             = "073457122123" -> null
      - tags                                 = {
          - "Name" = "fl-vpc"
        } -> null
      - tags_all                             = {
          - "Name" = "fl-vpc"
        } -> null
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 1 to destroy.