### PR TITLE
commiting palo alto terraform changes

### DIFF
--- a/home-lab/.terraform.lock.hcl
+++ b/home-lab/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.88.0"
+  hashes = [
+    "h1:Gsl/jrA6UmJI6iJg5HtQuZWERwWFyl8361jicsGEOj4=",
+    "zh:24f852b1cca276d91f950cb7fb575cacc385f55edccf4beec1f611cdd7626cf5",
+    "zh:2a3b3f5ac513f8d6448a31d9619f8a96e0597dd354459de3a4698e684c909f96",
+    "zh:3700499885a8e0e532eccba3cb068340e411cf9e616bf8a59e815d3b62ca3e46",
+    "zh:4aab3605468244a74cbde66784ea1d30dc0fc6caf26d1b099427ecd5790f7c4d",
+    "zh:74eca9314d6dd80b215d7bc1c4be37d81e1045d625d5b512995f3a352d7a43bc",
+    "zh:77d9a06c63a4ad615bc97f67f948250397267f15698ebb2547fbdd20f734983c",
+    "zh:82d6aaef1eb0caf9ca451887fdbdcff10ab09318b1d60faa883a013283ab2b15",
+    "zh:8dbcfb121b887ce8572f5ab8174d592a729390ca32dc5fdacac4c7c1c508411a",
+    "zh:95d51e80b55ff9064f5c1bc61d78f992e2f89c986ba2b10546ea4461d35c24f9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9ead5de0e123020926a0edaf88d9eed5cb86afe438a875528f6d11d0d27eed73",
+    "zh:ab7c940cbb2081314f4af3cdd61ed2c1d59fd7a60fa3db27770887d63072fbdd",
+    "zh:d52cd68006fd6fa8d028cdf569a6620fbc31726019beb7c75affa8764622d398",
+    "zh:f179ca86ad5d5fb88dfd8e8e7c448f2c0ad550d22152f939b8465baeaf9289e9",
+    "zh:f54dda271fa6dfee06537066278669a3f92c872e7dfa5a0184cd9117f7e47b8c",
+  ]
+}
+
+provider "registry.terraform.io/paloaltonetworks/panos" {
+  version     = "1.11.1"
+  constraints = "~> 1.11.1"
+  hashes = [
+    "h1:HZQv2pmumLkO4xSDDrGrGItyG9GUCgK/ce9QEtq6SGQ=",
+    "zh:195b9e561ee797635bca7b536e9d0a6ad5dea2423cc0d3ba98020b908073b176",
+    "zh:2b675b8331331090ff2b4717c2652dc5cfa149f9de9362b3e9ffa7c752cec8f9",
+    "zh:3a92172273b3ce35f96f59c073a808f7c753fcacdd3ee11e72bdf5f68c510190",
+    "zh:3ad53270f9f82a09ea593c3bff8a644f6d2aef5c76ed59e8da3a5e1cfa60eb3e",
+    "zh:3eba257a8029f3e4f2ba64504874599a250b04b23412e591e807afdbe446954a",
+    "zh:49aad3d16cdf993111d5bb2936f7977d56668ca50f8d88947f57cb04799b40a6",
+    "zh:4d565fd8aab70a242e4e7eed5ed9c32fa76dcb51146b2969e3ac1692b5f82759",
+    "zh:60030566efedb4e52716964a53e5283e5efd3a69e14311680a3b4306f65dc94d",
+    "zh:63c193e0271494dee46184a38516793e15f691845131732fa6f32797282e6972",
+    "zh:7ac3b2ca4cf0ad5188b6ef4d743a41ebe25d950b20d7080a41684e18432fc630",
+    "zh:9485778a66bb8c930725f0f7679047f7ee26a470c90895d2cc6fc8c69477f275",
+    "zh:9d3daffda4907d0524de046b95c462faf475457c3d1e26034150e58e138c2a94",
+    "zh:f55b34743f9cd897b5d708f4cc639b5398016b95f00589e0f2c4731f5214c8a6",
+    "zh:f987d5e36982ec7157a219e4fc9037d3be8aeac29034d4b8fd2baf96a0db8495",
+  ]
+}

--- a/home-lab/backend.tf
+++ b/home-lab/backend.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "terraform-bucket-tlyle-dev"
+    key            = "terraform/fl-state.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-lock-table-dev"
+    encrypt        = true
+  }
+}
+terraform {
+  required_providers {
+    panos = {
+      source = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}
+ provider "panos" {
+   hostname = "${var.fw_ip}"
+   username = "${var.username}"
+   password = "${var.password}"
+   
+ }

--- a/home-lab/main.tf
+++ b/home-lab/main.tf
@@ -1,0 +1,104 @@
+#add VLAN
+resource "panos_vlan" "vlan5" {
+    name = "TEST"
+    vlan_interface = panos_vlan_interface.vli.name 
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+
+#Creating vlan interface
+resource "panos_vlan_interface" "vli" {
+    name = "vlan.5"
+    vsys = "vsys1"    
+    static_ips = ["10.1.1.1/24"]
+    comment = "Configured for internal traffic"    
+    management_profile = "mgmt"  
+ 
+}
+#createing zone TEST
+resource "panos_zone" "TEST" {
+    name = "TEST"
+    mode = "layer3"
+    
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+#adding vlan.5 to zone
+resource "panos_zone_entry" "example" {
+    zone = panos_zone.TEST.name
+    interface = "vlan.5"
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+#add an interface in a VLAN on Panorama.
+resource "panos_vlan_entry" "example" {
+    vlan = panos_vlan.vlan5.name
+    interface = panos_layer2_subinterface.example.name
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+
+#adding l2 subinterface to aggregate interface
+resource "panos_layer2_subinterface" "example" {
+    parent_interface = "ae4"
+    interface_type = "aggregate-ethernet"
+    parent_mode = "layer2"
+    vsys = "vsys1"
+    name = "ae4.5"
+    tag = 5
+}
+
+#adding vlan to virtual router
+resource "panos_virtual_router_entry" "default" {
+    virtual_router = "default"
+    interface = panos_vlan_interface.vli.name
+
+    lifecycle {
+        create_before_destroy = true
+    }
+}
+# Creating all ethernet interfaces
+module "interfaces" {
+  source  = "../modules/interfaces"
+
+  mode = "ngfw" # If you want to use this module with a firewall, change this to "ngfw"
+
+  template = "test"
+  
+  interfaces = { 
+    "ae4" ={
+    type = "aggregate"    
+    name = "ae4"
+    mode = "layer2"
+    comment = "AE Group"
+    lacp_enable = true
+    }    
+    "ethernet1/3" = {
+      type                      = "ethernet"
+      mode                      = "aggregate-group"
+    #  management_profile        = "mgmt"
+      link_state                = "up"
+      enable_dhcp               = false
+      create_dhcp_default_route = false
+      #comment                   = "mgmt"
+      #virtual_router            = "default"
+      #zone                      = "mgmt"      
+      aggregate_group           = "ae4"
+    }
+    "ethernet1/4" = {
+      type               = "ethernet"
+      mode               = "aggregate-group"
+    #  management_profile = "mgmt"
+      link_state         = "up"
+      enable_dhcp        = false
+    #   comment            = "external"
+    #   virtual_router     = "external"
+    #   zone               = "external"     
+      aggregate_group    = "ae4"
+    }   
+  }
+}

--- a/home-lab/terraform.tfvars
+++ b/home-lab/terraform.tfvars
@@ -1,0 +1,5 @@
+fw_ip = "10.100.40.10"
+
+username = "tlyle"
+
+password = "Bigpimp@12345678"

--- a/home-lab/variables.tf
+++ b/home-lab/variables.tf
@@ -1,0 +1,3 @@
+variable fw_ip {}
+variable username {}
+variable password {}


### PR DESCRIPTION
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.interfaces.panos_ethernet_interface.this["ethernet1/3"] will be updated in-place
  ~ resource "panos_ethernet_interface" "this" {
        id                              = "vsys1:ethernet1/3"
        name                            = "ethernet1/3"
      ~ vsys                            = "(not vsys1)" -> "vsys1"
        # (27 unchanged attributes hidden)
    }

  # module.interfaces.panos_ethernet_interface.this["ethernet1/4"] will be updated in-place
  ~ resource "panos_ethernet_interface" "this" {
        id                              = "vsys1:ethernet1/4"
        name                            = "ethernet1/4"
      ~ vsys                            = "(not vsys1)" -> "vsys1"
        # (27 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
