### PR TITLE
cnf20022-add-moudles

### DIFF
--- a/modules/addresses/README.md
+++ b/modules/addresses/README.md
@@ -1,0 +1,111 @@
+Palo Alto Networks PAN-OS Address Module
+---
+This Terraform module allows users to configure address objects and address groups.
+
+For address objects, there are two options to use this module:
+- individual mode - create one `panos_address_obect` resource per object
+- bulk mode - create one `panos_address_obects` resource with multiple objects within
+
+Behaviour is controlled using `var.addresses_bulk_mode` - when set to `false` (default), individual mode is used, otherwise - bulk mode.
+Please see additional considerations when using the bulk mode - like recommended provider settings, terraform performance or lack of "import" capability in `panos_address_obects` resource [documentation](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_objects).
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "addresses" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/addresses"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group    = "test"
+  address_objects = {
+    DNS1 = {
+      "value"       = "1.1.1.1/32"
+      "type"        = "ip-netmask"
+      "description" = "DNS-SRV-Public-1"
+    },
+    DNS2 = {
+      "value"       = "1.0.0.1/32"
+      "type"        = "ip-netmask"
+      "description" = "DNS-SRV-Public-2"
+    },
+    DNS3 = {
+      "value"       = "8.8.4.4/32"
+      "type"        = "ip-netmask"
+      "description" = "DNS-GOOGLE-1"
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_address_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_group) | resource |
+| [panos_address_object.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_object) | resource |
+| [panos_address_objects.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_objects) | resource |
+| [panos_panorama_address_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_address_group) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if `var.mode` is `panorama`, defines the device group for the objects. | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if `var.mode` is `ngfw`, defines the vsys for the objects. | `string` | `"vsys1"` | no |
+| <a name="input_addresses_bulk_mode"></a> [addresses\_bulk\_mode](#input\_addresses\_bulk\_mode) | Determines whether each address object is managed as a separate `panos_address_object` resource (when set to `false`) or all within a single `panos_address_objects` resource that is dedicated for bulk operations. | `bool` | `false` | no |
+| <a name="input_address_objects"></a> [address\_objects](#input\_address\_objects) | Map of the address objects, where key is the address object's name:<br>- `type`: (optional) The type of address object. This can be ip-netmask (default), ip-range, fqdn, or ip-wildcard (PAN-OS 9.0+).<br>- `value`: (required) The address object's value. This can take various forms depending on what type of address object this is, but can be something like 192.168.80.150 or 192.168.80.0/24.<br>- `description`: (optional) The description of the address object.<br>- `tags`: (optional) List of administrative tags.<br><br>Example:<pre>{<br>  DNS-TAGS-1 = {<br>    value       = "1.1.1.1/32"<br>    type        = "ip-netmask"<br>    description = "DNS Server 1"<br>    tags        = ["DNS-SRV"]<br>  },<br>  PA-UPDATES = {<br>    type        = "fqdn"<br>    value       = "updates.paloaltonetworks.com"<br>    description = "Palo Alto updates"<br>  },<br>  NTP-RANGE-1 = {<br>    name  = "ntp1"<br>    type  = "ip-range"<br>    value = "10.0.0.2-10.0.0.10"<br>  }<br>}</pre> | <pre>map(object({<br>    value       = string<br>    type        = optional(string, "ip-netmask")<br>    description = optional(string)<br>    tags        = optional(list(string))<br>  }))</pre> | `{}` | no |
+| <a name="input_address_groups"></a> [address\_groups](#input\_address\_groups) | Map of the address group objects, where key is the address group's name:<br>- `members`: (optional) The address objects to include in this statically defined address group.<br>- `dynamic_match`: (optional) The IP tags to include in this DAG. Inputs are structured as follows `'<tag name>' and ...` or `<tag name>` or ...`.<br>- `description`: (optional) The description of the address group.<br>- `tags`: (optional) List of administrative tags.<br><br>Example:<br>`<pre>{<br>  AddressDeviceGroup = {<br>    members     = ["DNS1", "DNS2"]<br>    description = "DNS servers"<br>  }<br>  grp-dns-proxy = {<br>    dynamic_match = "dns-proxy'"<br>  }<br>}</pre> | <pre>map(object({<br>    members       = optional(list(string))<br>    dynamic_match = optional(string)<br>    description   = optional(string)<br>    tags          = optional(list(string))<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_addresses"></a> [addresses](#output\_addresses) | n/a |
+| <a name="output_address_groups"></a> [address\_groups](#output\_address\_groups) | n/a |
+| <a name="output_panorama_address_groups"></a> [panorama\_address\_groups](#output\_panorama\_address\_groups) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/addresses/main.tf
+++ b/modules/addresses/main.tf
@@ -1,0 +1,87 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_address_object" "this" {
+  for_each = var.addresses_bulk_mode ? {} : var.address_objects
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  name        = each.key
+  value       = each.value.value
+  type        = each.value.type
+  description = each.value.description
+  tags        = each.value.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_address_objects" "this" {
+  for_each = var.addresses_bulk_mode ? toset([for mode in keys(local.mode_map) : mode if mode == var.mode]) : []
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  dynamic "object" {
+    for_each = var.address_objects
+
+    content {
+      name        = object.key
+      type        = object.value.type
+      value       = object.value.value
+      description = object.value.description
+      tags        = object.value.tags
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_address_group" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.address_groups : {}
+
+  device_group = var.device_group
+
+  name             = each.key
+  static_addresses = each.value.members
+  dynamic_match    = each.value.dynamic_match
+  description      = each.value.description
+  tags             = each.value.tags
+
+  depends_on = [
+    panos_address_object.this
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_address_group" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.address_groups : {}
+
+  vsys = var.vsys
+
+  name             = each.key
+  static_addresses = each.value.members
+  dynamic_match    = each.value.dynamic_match
+  description      = each.value.description
+  tags             = each.value.tags
+
+  depends_on = [
+    panos_address_object.this
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/addresses/main_test.go
+++ b/modules/addresses/main_test.go
@@ -1,0 +1,11 @@
+package addresses
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/addresses/outputs.tf
+++ b/modules/addresses/outputs.tf
@@ -1,0 +1,11 @@
+output "addresses" {
+  value = var.addresses_bulk_mode ? panos_address_objects.this : panos_address_object.this
+}
+
+output "address_groups" {
+  value = panos_address_group.this
+}
+
+output "panorama_address_groups" {
+  value = panos_panorama_address_group.this
+}

--- a/modules/addresses/variables.tf
+++ b/modules/addresses/variables.tf
@@ -1,0 +1,100 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_group" {
+  description = "Used if `var.mode` is `panorama`, defines the device group for the objects."
+  default     = "shared"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if `var.mode` is `ngfw`, defines the vsys for the objects."
+  default     = "vsys1"
+  type        = string
+}
+
+variable "addresses_bulk_mode" {
+  description = "Determines whether each address object is managed as a separate `panos_address_object` resource (when set to `false`) or all within a single `panos_address_objects` resource that is dedicated for bulk operations."
+  default     = false
+  type        = bool
+}
+
+variable "address_objects" {
+  description = <<-EOF
+  Map of the address objects, where key is the address object's name:
+  - `type`: (optional) The type of address object. This can be ip-netmask (default), ip-range, fqdn, or ip-wildcard (PAN-OS 9.0+).
+  - `value`: (required) The address object's value. This can take various forms depending on what type of address object this is, but can be something like 192.168.80.150 or 192.168.80.0/24.
+  - `description`: (optional) The description of the address object.
+  - `tags`: (optional) List of administrative tags.
+
+  Example:
+  ```
+  {
+    DNS-TAGS-1 = {
+      value       = "1.1.1.1/32"
+      type        = "ip-netmask"
+      description = "DNS Server 1"
+      tags        = ["DNS-SRV"]
+    },
+    PA-UPDATES = {
+      type        = "fqdn"
+      value       = "updates.paloaltonetworks.com"
+      description = "Palo Alto updates"
+    },
+    NTP-RANGE-1 = {
+      name  = "ntp1"
+      type  = "ip-range"
+      value = "10.0.0.2-10.0.0.10"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    value       = string
+    type        = optional(string, "ip-netmask")
+    description = optional(string)
+    tags        = optional(list(string))
+  }))
+  validation {
+    condition     = alltrue([for address_object in var.address_objects : contains(["ip-netmask", "ip-range", "fqdn", "ip-wildcard"], address_object.type)])
+    error_message = "Valid values of type are `ip-netmask` (default), `ip-range`, `fqdn`, or `ip-wildcard`"
+  }
+}
+
+variable "address_groups" {
+  description = <<-EOF
+  Map of the address group objects, where key is the address group's name:
+  - `members`: (optional) The address objects to include in this statically defined address group.
+  - `dynamic_match`: (optional) The IP tags to include in this DAG. Inputs are structured as follows `'<tag name>' and ...` or `<tag name>` or ...`.
+  - `description`: (optional) The description of the address group.
+  - `tags`: (optional) List of administrative tags.
+
+  Example:
+  ```
+  {
+    AddressDeviceGroup = {
+      members     = ["DNS1", "DNS2"]
+      description = "DNS servers"
+    }
+    grp-dns-proxy = {
+      dynamic_match = "dns-proxy'"
+    }
+  }
+  ```
+  EOF
+
+  default = {}
+  type = map(object({
+    members       = optional(list(string))
+    dynamic_match = optional(string)
+    description   = optional(string)
+    tags          = optional(list(string))
+  }))
+}

--- a/modules/addresses/versions.tf
+++ b/modules/addresses/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/device_groups/README.md
+++ b/modules/device_groups/README.md
@@ -1,0 +1,84 @@
+Palo Alto Networks PAN-OS Device Groups Module
+---
+This Terraform module allows users to configure device groups.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "device_groups" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/device_groups"
+
+  mode = "panorama"
+
+  device_groups = {
+    "aws-test-dg" = {
+      description = "Device group used for AWS cloud"
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_device_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/device_group) | resource |
+| [panos_device_group_entry.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/device_group_entry) | resource |
+| [panos_device_group_parent.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/device_group_parent) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_groups"></a> [device\_groups](#input\_device\_groups) | Map of device group where the key is name of the device group.<br>  - `serial` - (Required) The serial number of the firewall.<br>  - `parent` - (Optional) The parent device group name. Leaving this empty / unspecified means to move this device group under the "shared" device group.<br>  - `vsys_list` - (Optional) A subset of all available vsys on the firewall that should be in this device group. If the firewall is a virtual firewall, then this parameter should just be omitted.<pre>{<br>  "aws-test-dg" = {<br>    description = "Device group used for AWS cloud"<br>    device_group_entries = {<br>    serial = "1111222233334444"<br>    parent = "clouds"<br>  }<br>}</pre> | <pre>map(object({<br>    description = string<br>    parent      = optional(string)<br>    serial      = optional(list(string), [])<br>    vsys_list   = optional(list(string), [])<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_device_groups"></a> [device\_groups](#output\_device\_groups) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/device_groups/main.tf
+++ b/modules/device_groups/main.tf
@@ -1,0 +1,46 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+  dg_entries = flatten([for dk, dv in var.device_groups : [for ds in dv.serial : { dg = dk, serial = ds, vsys_list = dv.vsys_list }]])
+}
+
+resource "panos_device_group" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.device_groups : {}
+
+  name        = each.key
+  description = each.value.description
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_device_group_entry" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? { for i in local.dg_entries : "${i.dg}_${i.serial}" => i } : {}
+
+  device_group = each.value.dg
+  serial       = each.value.serial
+  vsys_list    = each.value.vsys_list
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [panos_device_group.this]
+}
+
+resource "panos_device_group_parent" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? { for k, v in var.device_groups : k => v if try(v.parent, null) != null } : {}
+
+  device_group = each.key
+  parent       = each.value.parent
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [panos_device_group.this]
+}

--- a/modules/device_groups/main_test.go
+++ b/modules/device_groups/main_test.go
@@ -1,0 +1,11 @@
+package device_groups
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/device_groups/outputs.tf
+++ b/modules/device_groups/outputs.tf
@@ -1,0 +1,3 @@
+output "device_groups" {
+  value = panos_device_group.this
+}

--- a/modules/device_groups/variables.tf
+++ b/modules/device_groups/variables.tf
@@ -1,0 +1,37 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_groups" {
+  description = <<-EOF
+  Map of device group where the key is name of the device group.
+  - `serial` - (Required) The serial number of the firewall.
+  - `parent` - (Optional) The parent device group name. Leaving this empty / unspecified means to move this device group under the "shared" device group.
+  - `vsys_list` - (Optional) A subset of all available vsys on the firewall that should be in this device group. If the firewall is a virtual firewall, then this parameter should just be omitted.
+
+```
+{
+  "aws-test-dg" = {
+    description = "Device group used for AWS cloud"
+    device_group_entries = {
+    serial = "1111222233334444"
+    parent = "clouds"
+  }
+}
+```
+
+EOF
+
+  default = {}
+  type = map(object({
+    description = string
+    parent      = optional(string)
+    serial      = optional(list(string), [])
+    vsys_list   = optional(list(string), [])
+  }))
+}

--- a/modules/device_groups/versions.tf
+++ b/modules/device_groups/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/interfaces/README.md
+++ b/modules/interfaces/README.md
@@ -1,0 +1,119 @@
+Palo Alto Networks PAN-OS Interfaces Module
+---
+This Terraform module allows users to configure interfaces.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "interfaces" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/interfaces"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  template = "test"
+
+  interfaces = {
+    "ethernet1/1" = {
+      type                      = "ethernet"
+      mode                      = "layer3"
+      management_profile        = "mgmt_default"
+      link_state                = "up"
+      enable_dhcp               = true
+      create_dhcp_default_route = false
+      comment                   = "mgmt"
+      virtual_router            = "vr"
+      zone                      = "mgmt"
+      vsys                      = "vsys1"
+    }
+    "ethernet1/2" = {
+      type               = "ethernet"
+      mode               = "layer3"
+      management_profile = "mgmt_default"
+      link_state         = "up"
+      comment            = "external"
+      virtual_router     = "external"
+      zone               = "external"
+      vsys               = "vsys1"
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_ethernet_interface.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/ethernet_interface) | resource |
+| [panos_loopback_interface.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/loopback_interface) | resource |
+| [panos_panorama_ethernet_interface.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_ethernet_interface) | resource |
+| [panos_panorama_loopback_interface.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_loopback_interface) | resource |
+| [panos_panorama_tunnel_interface.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_tunnel_interface) | resource |
+| [panos_tunnel_interface.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/tunnel_interface) | resource |
+| [panos_virtual_router_entry.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/virtual_router_entry) | resource |
+| [panos_zone_entry.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/zone_entry) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_template"></a> [template](#input\_template) | The template name. | `string` | `"default"` | no |
+| <a name="input_template_stack"></a> [template\_stack](#input\_template\_stack) | The template stack name. | `string` | `""` | no |
+| <a name="input_interfaces"></a> [interfaces](#input\_interfaces) | Map of the interfaces, where key is the interface's name. Following parameters are available for all interface types:<br>- `type` - (Required) Type of interface. Valid values are `ethernet`,`loopback`,`tunnel`.<br>- `zone` - (Optional) The zone's name<br>- `virtual_router` - (Optional) The virtual router's name<br>- `vsys` - (Optional) The vsys that will use this interface (default: vsys1). This should be something like vsys1 or vsys3.<br>- `static_ips` - (Optional) List of static IPv4 addresses to set for this data interface.<br>- `management_profile` - (Optional) The management profile.<br>- `netflow_profile` - (Optional) The netflow profile.<br>- `mtu` - (Optional) The MTU.<br>- `comment` - (Optional) The interface comment.<br><br>Additional parameters available for `ethernet` and `loopback` interface types:<br>- `adjust_tcp_mss` - (Optional) Adjust TCP MSS (default: false).<br>- `ipv4_mss_adjust` - (Optional, PAN-OS 7.1+) The IPv4 MSS adjust value.<br>- `ipv6_mss_adjust` - (Optional, PAN-OS 7.1+) The IPv6 MSS adjust value.<br><br>Parameters available only for `ethernet` interfaces:<br>- `mode` - (Optional) The interface mode, required for `ethernet` interfaces. This can be any of the following values: layer3, layer2, virtual-wire, tap, ha, decrypt-mirror, or aggregate-group.<br>- `enable_dhcp` - (Optional) Set to true to enable DHCP on this interface.<br>- `create_dhcp_default_route` - (Optional) Set to true to create a DHCP default route.<br>- `dhcp_default_route_metric` - (Optional) The metric for the DHCP default route.<br>- `ipv6_enabled` - (Optional) Set to true to enable IPv6.<br>- `lldp_enabled` - (Optional) Enable LLDP (default: false).<br>- `lldp_profile` - (Optional) LLDP profile.<br>- `lldp_ha_passive_pre_negotiation` - (bool) LLDP HA passive pre-negotiation.<br>- `lacp_ha_passive_pre_negotiation` - (bool) LACP HA passive pre-negotiation.<br>- `link_speed` - (Optional) Link speed. This can be any of the following: 10, 100, 1000, or auto.<br>- `link_duplex` - (Optional) Link duplex setting. This can be full, half, or auto.<br>- `link_state` - (Optional) The link state. This can be up, down, or auto.<br>- `aggregate_group` - (Optional) The aggregate group (applicable for physical firewalls only).<br>- `lacp_port_priority` - (int) LACP port priority.<br>- `decrypt_forward` - (Optional, PAN-OS 8.1+) Enable decrypt forwarding.<br>- `rx_policing_rate` - (Optional, PAN-OS 8.1+) Receive policing rate in Mbps.<br>- `tx_policing_rate` - (Optional, PAN-OS 8.1+) Transmit policing rate in Mbps.<br>- `dhcp_send_hostname_enable` - (Optional, PAN-OS 9.0+) For DHCP layer3 interfaces: enable sending the firewall or a custom hostname to DHCP server<br>- `dhcp_send_hostname_value` - (Optional, PAN-OS 9.0+) For DHCP layer3 interfaces: the interface hostname. Leaving this unspecified with dhcp\_send\_hostname\_enable set means to send the system hostname.<br><br>Example:<pre>{<br>  "ethernet1/1" = {<br>    type                      = "ethernet"<br>    mode                      = "layer3"<br>    management_profile        = "mgmt_default"<br>    link_state                = "up"<br>    enable_dhcp               = true<br>    create_dhcp_default_route = false<br>    comment                   = "mgmt"<br>    virtual_router            = "default"<br>    zone                      = "mgmt"<br>    vsys                      = "vsys1"<br>  }<br>}</pre> | <pre>map(object({<br>    type                            = string<br>    mode                            = optional(string)<br>    zone                            = optional(string)<br>    virtual_router                  = optional(string)<br>    vsys                            = optional(string, "vsys1")<br>    static_ips                      = optional(list(string), [])<br>    enable_dhcp                     = optional(bool, false)<br>    create_dhcp_default_route       = optional(bool, false)<br>    dhcp_default_route_metric       = optional(number)<br>    ipv6_enabled                    = optional(bool)<br>    management_profile              = optional(string)<br>    mtu                             = optional(number)<br>    adjust_tcp_mss                  = optional(bool, false)<br>    netflow_profile                 = optional(string)<br>    lldp_enabled                    = optional(bool, false)<br>    lldp_profile                    = optional(string)<br>    lldp_ha_passive_pre_negotiation = optional(bool)<br>    lacp_ha_passive_pre_negotiation = optional(bool)<br>    link_speed                      = optional(string)<br>    link_duplex                     = optional(string)<br>    link_state                      = optional(string)<br>    aggregate_group                 = optional(string)<br>    comment                         = optional(string)<br>    lacp_port_priority              = optional(number)<br>    ipv4_mss_adjust                 = optional(string)<br>    ipv6_mss_adjust                 = optional(string)<br>    decrypt_forward                 = optional(bool)<br>    rx_policing_rate                = optional(number)<br>    tx_policing_rate                = optional(number)<br>    dhcp_send_hostname_enable       = optional(bool)<br>    dhcp_send_hostname_value        = optional(string)<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panorama_ethernet_interfaces"></a> [panorama\_ethernet\_interfaces](#output\_panorama\_ethernet\_interfaces) | n/a |
+| <a name="output_ethernet_interfaces"></a> [ethernet\_interfaces](#output\_ethernet\_interfaces) | n/a |
+| <a name="output_panorama_loopback_interfaces"></a> [panorama\_loopback\_interfaces](#output\_panorama\_loopback\_interfaces) | n/a |
+| <a name="output_loopback_interfaces"></a> [loopback\_interfaces](#output\_loopback\_interfaces) | n/a |
+| <a name="output_panorama_tunnel_interfaces"></a> [panorama\_tunnel\_interfaces](#output\_panorama\_tunnel\_interfaces) | n/a |
+| <a name="output_tunnel_interfaces"></a> [tunnel\_interfaces](#output\_tunnel\_interfaces) | n/a |
+| <a name="output_virtual_router_entries"></a> [virtual\_router\_entries](#output\_virtual\_router\_entries) | n/a |
+| <a name="output_zone_entries"></a> [zone\_entries](#output\_zone\_entries) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/interfaces/main.tf
+++ b/modules/interfaces/main.tf
@@ -1,0 +1,220 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_panorama_ethernet_interface" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? { for name, intf in var.interfaces : name => intf if intf.type == "ethernet" } : {}
+
+  template = var.template
+  ### an argument named "template_stack" is not expected here
+
+  name                            = each.key
+  vsys                            = each.value.vsys
+  mode                            = each.value.mode
+  management_profile              = each.value.management_profile
+  link_state                      = each.value.link_state
+  static_ips                      = each.value.static_ips
+  enable_dhcp                     = each.value.enable_dhcp
+  create_dhcp_default_route       = each.value.create_dhcp_default_route
+  dhcp_default_route_metric       = each.value.dhcp_default_route_metric
+  ipv6_enabled                    = each.value.ipv6_enabled
+  mtu                             = each.value.mtu
+  adjust_tcp_mss                  = each.value.adjust_tcp_mss
+  netflow_profile                 = each.value.netflow_profile
+  lldp_enabled                    = each.value.lldp_enabled
+  lldp_profile                    = each.value.lldp_profile
+  lldp_ha_passive_pre_negotiation = each.value.lldp_ha_passive_pre_negotiation
+  lacp_ha_passive_pre_negotiation = each.value.lacp_ha_passive_pre_negotiation
+  link_speed                      = each.value.link_speed
+  link_duplex                     = each.value.link_duplex
+  aggregate_group                 = each.value.aggregate_group
+  lacp_port_priority              = each.value.lacp_port_priority
+  ipv4_mss_adjust                 = each.value.ipv4_mss_adjust
+  ipv6_mss_adjust                 = each.value.ipv6_mss_adjust
+  decrypt_forward                 = each.value.decrypt_forward
+  rx_policing_rate                = each.value.rx_policing_rate
+  tx_policing_rate                = each.value.tx_policing_rate
+  dhcp_send_hostname_enable       = each.value.dhcp_send_hostname_enable
+  dhcp_send_hostname_value        = each.value.dhcp_send_hostname_value
+  comment                         = each.value.comment
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_ethernet_interface" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? { for name, intf in var.interfaces : name => intf if intf.type == "ethernet" } : {}
+
+  name                            = each.key
+  vsys                            = each.value.vsys
+  mode                            = each.value.mode
+  management_profile              = each.value.management_profile
+  link_state                      = each.value.link_state
+  static_ips                      = each.value.static_ips
+  enable_dhcp                     = each.value.enable_dhcp
+  create_dhcp_default_route       = each.value.create_dhcp_default_route
+  dhcp_default_route_metric       = each.value.dhcp_default_route_metric
+  ipv6_enabled                    = each.value.ipv6_enabled
+  mtu                             = each.value.mtu
+  adjust_tcp_mss                  = each.value.adjust_tcp_mss
+  netflow_profile                 = each.value.netflow_profile
+  lldp_enabled                    = each.value.lldp_enabled
+  lldp_profile                    = each.value.lldp_profile
+  lldp_ha_passive_pre_negotiation = each.value.lldp_ha_passive_pre_negotiation
+  lacp_ha_passive_pre_negotiation = each.value.lacp_ha_passive_pre_negotiation
+  link_speed                      = each.value.link_speed
+  link_duplex                     = each.value.link_duplex
+  aggregate_group                 = each.value.aggregate_group
+  lacp_port_priority              = each.value.lacp_port_priority
+  ipv4_mss_adjust                 = each.value.ipv4_mss_adjust
+  ipv6_mss_adjust                 = each.value.ipv6_mss_adjust
+  decrypt_forward                 = each.value.decrypt_forward
+  rx_policing_rate                = each.value.rx_policing_rate
+  tx_policing_rate                = each.value.tx_policing_rate
+  dhcp_send_hostname_enable       = each.value.dhcp_send_hostname_enable
+  dhcp_send_hostname_value        = each.value.dhcp_send_hostname_value
+  comment                         = each.value.comment
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_loopback_interface" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? { for name, intf in var.interfaces : name => intf if intf.type == "loopback" } : {}
+
+  template = var.template
+  ### an argument named "template_stack" is not expected here
+
+  name               = each.key
+  vsys               = each.value.vsys
+  management_profile = each.value.management_profile
+  mtu                = each.value.mtu
+  netflow_profile    = each.value.netflow_profile
+  static_ips         = each.value.static_ips
+  adjust_tcp_mss     = each.value.adjust_tcp_mss
+  ipv4_mss_adjust    = each.value.ipv4_mss_adjust
+  ipv6_mss_adjust    = each.value.ipv6_mss_adjust
+  comment            = each.value.comment
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_loopback_interface" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? { for name, intf in var.interfaces : name => intf if intf.type == "loopback" } : {}
+
+  name               = each.key
+  vsys               = each.value.vsys
+  management_profile = each.value.management_profile
+  mtu                = each.value.mtu
+  netflow_profile    = each.value.netflow_profile
+  static_ips         = each.value.static_ips
+  adjust_tcp_mss     = each.value.adjust_tcp_mss
+  ipv4_mss_adjust    = each.value.ipv4_mss_adjust
+  ipv6_mss_adjust    = each.value.ipv6_mss_adjust
+  comment            = each.value.comment
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_tunnel_interface" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? { for name, intf in var.interfaces : name => intf if intf.type == "tunnel" } : {}
+
+  template = var.template
+  ### an argument named "template_stack" is not expected here
+
+  name               = each.key
+  vsys               = each.value.vsys
+  management_profile = each.value.management_profile
+  mtu                = each.value.mtu
+  netflow_profile    = each.value.netflow_profile
+  static_ips         = each.value.static_ips
+  comment            = each.value.comment
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_tunnel_interface" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? { for name, intf in var.interfaces : name => intf if intf.type == "tunnel" } : {}
+
+  name               = each.key
+  vsys               = each.value.vsys
+  management_profile = each.value.management_profile
+  mtu                = each.value.mtu
+  netflow_profile    = each.value.netflow_profile
+  static_ips         = each.value.static_ips
+  comment            = each.value.comment
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "panos_aggregate_interface" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? { for name, intf in var.interfaces : name => intf if intf.type == "aggregate" } : {}
+  
+  name               = each.key
+  mode               = each.value.mode
+  vsys               = each.value.vsys
+  management_profile = each.value.management_profile
+  mtu                = each.value.mtu 
+  comment            = each.value.comment
+  lacp_enable        = each.value.lacp_enable   
+
+}
+resource "panos_virtual_router_entry" "this" {
+  for_each = { for k, v in var.interfaces : "${v.virtual_router}_${k}" => { interface = k, virtual_router = v.virtual_router } if try(v.virtual_router, null) != null }
+
+  template       = local.mode_map[var.mode] == 0 ? (var.template_stack == "" ? var.template : null) : null
+  template_stack = local.mode_map[var.mode] == 0 ? var.template_stack == "" ? null : var.template_stack : null
+
+  virtual_router = try(each.value.virtual_router, "default")
+  interface      = each.value.interface
+
+  depends_on = [
+    panos_panorama_ethernet_interface.this,
+    panos_panorama_loopback_interface.this,
+    panos_panorama_tunnel_interface.this,
+    panos_ethernet_interface.this,
+    panos_loopback_interface.this,
+    panos_tunnel_interface.this,
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_zone_entry" "this" {
+  for_each = { for k, v in var.interfaces : "${v.zone}_${k}" => { interface = k, zone = v.zone, vsys = v.vsys } if try(v.zone, null) != null }
+
+  template       = local.mode_map[var.mode] == 0 ? (var.template_stack == "" ? var.template : null) : null
+  template_stack = local.mode_map[var.mode] == 0 ? var.template_stack == "" ? null : var.template_stack : null
+
+  vsys      = try(each.value.vsys, "none")
+  zone      = each.value.zone
+  interface = each.value.interface
+
+  depends_on = [
+    panos_panorama_ethernet_interface.this,
+    panos_panorama_loopback_interface.this,
+    panos_panorama_tunnel_interface.this,
+    panos_ethernet_interface.this,
+    panos_loopback_interface.this,
+    panos_tunnel_interface.this,
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/interfaces/main_test.go
+++ b/modules/interfaces/main_test.go
@@ -1,0 +1,11 @@
+package interfaces
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/interfaces/outputs.tf
+++ b/modules/interfaces/outputs.tf
@@ -1,0 +1,31 @@
+output "panorama_ethernet_interfaces" {
+  value = panos_panorama_ethernet_interface.this
+}
+
+output "ethernet_interfaces" {
+  value = panos_ethernet_interface.this
+}
+
+output "panorama_loopback_interfaces" {
+  value = panos_panorama_loopback_interface.this
+}
+
+output "loopback_interfaces" {
+  value = panos_loopback_interface.this
+}
+
+output "panorama_tunnel_interfaces" {
+  value = panos_panorama_tunnel_interface.this
+}
+
+output "tunnel_interfaces" {
+  value = panos_tunnel_interface.this
+}
+
+output "virtual_router_entries" {
+  value = panos_virtual_router_entry.this
+}
+
+output "zone_entries" {
+  value = panos_zone_entry.this
+}

--- a/modules/interfaces/variables.tf
+++ b/modules/interfaces/variables.tf
@@ -1,0 +1,134 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "template" {
+  description = "The template name."
+  default     = "default"
+  type        = string
+}
+
+variable "template_stack" {
+  description = "The template stack name."
+  default     = ""
+  type        = string
+}
+
+variable "interfaces" {
+  description = <<-EOF
+  Map of the interfaces, where key is the interface's name. Following parameters are available for all interface types:
+  - `type` - (Required) Type of interface. Valid values are `ethernet`,`loopback`,`tunnel`.
+  - `zone` - (Optional) The zone's name
+  - `virtual_router` - (Optional) The virtual router's name
+  - `vsys` - (Optional) The vsys that will use this interface (default: none). This should be something like vsys1 or vsys3.
+  - `static_ips` - (Optional) List of static IPv4 addresses to set for this data interface.
+  - `management_profile` - (Optional) The management profile.
+  - `netflow_profile` - (Optional) The netflow profile.
+  - `mtu` - (Optional) The MTU.
+  - `comment` - (Optional) The interface comment.
+
+  Additional parameters available for `ethernet` and `loopback` interface types:
+  - `adjust_tcp_mss` - (Optional) Adjust TCP MSS (default: false).
+  - `ipv4_mss_adjust` - (Optional, PAN-OS 7.1+) The IPv4 MSS adjust value.
+  - `ipv6_mss_adjust` - (Optional, PAN-OS 7.1+) The IPv6 MSS adjust value.
+
+  Parameters available only for `ethernet` interfaces:
+  - `mode` - (Optional) The interface mode, required for `ethernet` interfaces. This can be any of the following values: layer3, layer2, virtual-wire, tap, ha, decrypt-mirror, or aggregate-group.
+  - `enable_dhcp` - (Optional) Set to true to enable DHCP on this interface.
+  - `create_dhcp_default_route` - (Optional) Set to true to create a DHCP default route.
+  - `dhcp_default_route_metric` - (Optional) The metric for the DHCP default route.
+  - `ipv6_enabled` - (Optional) Set to true to enable IPv6.
+  - `lldp_enabled` - (Optional) Enable LLDP (default: false).
+  - `lldp_profile` - (Optional) LLDP profile.
+  - `lldp_ha_passive_pre_negotiation` - (bool) LLDP HA passive pre-negotiation.
+  - `lacp_ha_passive_pre_negotiation` - (bool) LACP HA passive pre-negotiation.
+  - `link_speed` - (Optional) Link speed. This can be any of the following: 10, 100, 1000, or auto.
+  - `link_duplex` - (Optional) Link duplex setting. This can be full, half, or auto.
+  - `link_state` - (Optional) The link state. This can be up, down, or auto.
+  - `aggregate_group` - (Optional) The aggregate group (applicable for physical firewalls only).
+  - `lacp_port_priority` - (int) LACP port priority.
+  - `decrypt_forward` - (Optional, PAN-OS 8.1+) Enable decrypt forwarding.
+  - `rx_policing_rate` - (Optional, PAN-OS 8.1+) Receive policing rate in Mbps.
+  - `tx_policing_rate` - (Optional, PAN-OS 8.1+) Transmit policing rate in Mbps.
+  - `dhcp_send_hostname_enable` - (Optional, PAN-OS 9.0+) For DHCP layer3 interfaces: enable sending the firewall or a custom hostname to DHCP server
+  - `dhcp_send_hostname_value` - (Optional, PAN-OS 9.0+) For DHCP layer3 interfaces: the interface hostname. Leaving this unspecified with dhcp_send_hostname_enable set means to send the system hostname.
+
+  Example:
+  ```
+  {
+    "ethernet1/1" = {
+      type                      = "ethernet"
+      mode                      = "layer3"
+      management_profile        = "mgmt_default"
+      link_state                = "up"
+      enable_dhcp               = true
+      create_dhcp_default_route = false
+      comment                   = "mgmt"
+      virtual_router            = "default"
+      zone                      = "mgmt"
+      vsys                      = "vsys1"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    type                            = string
+    mode                            = optional(string)
+    zone                            = optional(string)
+    virtual_router                  = optional(string)
+    vsys                            = optional(string)
+    static_ips                      = optional(list(string), [])
+    enable_dhcp                     = optional(bool, false)
+    create_dhcp_default_route       = optional(bool, false)
+    dhcp_default_route_metric       = optional(number)
+    ipv6_enabled                    = optional(bool)
+    management_profile              = optional(string)
+    mtu                             = optional(number)
+    adjust_tcp_mss                  = optional(bool, false)
+    netflow_profile                 = optional(string)
+    lacp_enable                     = optional(bool, false)
+    lldp_enabled                    = optional(bool, false)
+    lldp_profile                    = optional(string)
+    lldp_ha_passive_pre_negotiation = optional(bool)
+    lacp_ha_passive_pre_negotiation = optional(bool)
+    link_speed                      = optional(string)
+    link_duplex                     = optional(string)
+    link_state                      = optional(string)
+    aggregate_group                 = optional(string)
+    comment                         = optional(string)
+    lacp_port_priority              = optional(number)
+    ipv4_mss_adjust                 = optional(string)
+    ipv6_mss_adjust                 = optional(string)
+    decrypt_forward                 = optional(bool)
+    rx_policing_rate                = optional(number)
+    tx_policing_rate                = optional(number)
+    dhcp_send_hostname_enable       = optional(bool)
+    dhcp_send_hostname_value        = optional(string)
+  }))
+  validation {
+    condition     = alltrue([for interface in var.interfaces : contains(["layer3", "layer2", "virtual-wire", "tap", "ha", "decrypt-mirror", "aggregate-group"], coalesce(interface.mode, "")) if interface.type == "ethernet"])
+    error_message = "Valid mode values for 'ethernet' interfaces are `layer3`, `layer2`, `virtual-wire`, `tap`, `ha`, `decrypt-mirror`, or `aggregate-group`"
+  }
+  validation {
+    condition     = alltrue([for interface in var.interfaces : contains(["ethernet", "loopback", "tunnel", "aggregate"], interface.type)])
+    error_message = "Valid types of interfaces are `ethernet`,`loopback`,`tunnel`"
+  }
+  validation {
+    condition     = alltrue([for interface in var.interfaces : contains(["up", "down", "auto"], coalesce(interface.link_state, "up"))])
+    error_message = "Valid link state values are `up`, `down`, `auto`"
+  }
+  validation {
+    condition     = alltrue([for interface in var.interfaces : contains(["10", "100", "1000", "auto"], coalesce(interface.link_speed, "auto"))])
+    error_message = "Valid link speed values are `10`, `100`, `1000`, or `auto`"
+  }
+  validation {
+    condition     = alltrue([for interface in var.interfaces : contains(["full", "half", "auto"], coalesce(interface.link_duplex, "auto"))])
+    error_message = "Valid link duplex values are `full`, `half`, or `auto`"
+  }
+}

--- a/modules/interfaces/versions.tf
+++ b/modules/interfaces/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/ipsec/README.md
+++ b/modules/ipsec/README.md
@@ -1,0 +1,167 @@
+Palo Alto Networks PAN-OS IPSec Module
+---
+This Terraform module allows users to configure IPSec.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "ipsec" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/ipsec"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  template = "test"
+
+  ike_crypto_profiles = {
+    "AES128_default" = {
+      dh_groups               = ["group2", "group5"]
+      authentications         = ["md5", "sha1"]
+      encryptions             = ["aes-128-cbc", "aes-192-cbc"]
+      lifetime_type           = "hours"
+      lifetime_value          = 24
+      authentication_multiple = 0
+    }
+    "AES128_DH5" = {
+      dh_groups               = ["group5"]
+      authentications         = ["sha1"]
+      encryptions             = ["aes-128-cbc", "aes-192-cbc"]
+      lifetime_type           = "hours"
+      lifetime_value          = 8
+      authentication_multiple = 3
+    }
+  }
+  ipsec_crypto_profiles = {
+    "AES128_default" = {
+      protocol        = "esp"
+      authentications = ["md5", "sha1"]
+      encryptions     = ["aes-128-cbc", "aes-192-cbc"]
+      dh_group        = "group5"
+      lifetime_type   = "hours"
+      lifetime_value  = 24
+    }
+    "AES128_DH14" = {
+      protocol        = "esp"
+      authentications = ["sha1"]
+      encryptions     = ["aes-128-cbc", "aes-192-cbc"]
+      dh_group        = "group14"
+      lifetime_type   = "hours"
+      lifetime_value  = 24
+    }
+  }
+  ike_gateways = {
+    "IKE-GW-1" = {
+      version              = "ikev1"
+      disabled             = false
+      peer_ip_type         = "ip"
+      peer_ip_value        = "5.5.5.5"
+      interface            = "ethernet1/1"
+      pre_shared_key       = "test12345"
+      local_id_type        = "ipaddr"
+      local_id_value       = "10.1.1.1"
+      peer_id_type         = "ipaddr"
+      peer_id_value        = "10.5.1.1"
+      ikev1_crypto_profile = "AES128_default"
+    }
+  }
+  ipsec_tunnels = {
+    "some_tunnel" = {
+      virtual_router          = "internal"
+      tunnel_interface        = "tunnel.42"
+      type                    = "auto-key"
+      disabled                = false
+      ak_ike_gateway          = "IKE-GW-1"
+      ak_ipsec_crypto_profile = "AES128_DH14"
+      anti_replay             = false
+      copy_flow_label         = false
+      enable_tunnel_monitor   = false
+      proxy_subnets           = "example1,10.10.10.0/24,10.10.20.0/24;example2,10.10.10.0/24,10.10.30.0/24"
+    }
+  }
+  ipsec_tunnel_proxies  = {}
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_ike_crypto_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/ike_crypto_profile) | resource |
+| [panos_ike_gateway.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/ike_gateway) | resource |
+| [panos_ipsec_crypto_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/ipsec_crypto_profile) | resource |
+| [panos_ipsec_tunnel.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/ipsec_tunnel) | resource |
+| [panos_ipsec_tunnel_proxy_id_ipv4.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/ipsec_tunnel_proxy_id_ipv4) | resource |
+| [panos_panorama_ike_gateway.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_ike_gateway) | resource |
+| [panos_panorama_ipsec_crypto_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_ipsec_crypto_profile) | resource |
+| [panos_panorama_ipsec_tunnel.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_ipsec_tunnel) | resource |
+| [panos_panorama_ipsec_tunnel_proxy_id_ipv4.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_ipsec_tunnel_proxy_id_ipv4) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_template"></a> [template](#input\_template) | The template name. | `string` | `"default"` | no |
+| <a name="input_template_stack"></a> [template\_stack](#input\_template\_stack) | The template stack name. | `string` | `""` | no |
+| <a name="input_ike_crypto_profiles"></a> [ike\_crypto\_profiles](#input\_ike\_crypto\_profiles) | Map of the IKE crypto profiles, where key is the IKE crypto profile's name:<br>- `dh_groups` - (Required, list) List of DH Group entries. Values should have a prefix if group.<br>- `authentications` - (Required, list) List of authentication types. This c<br>- `encryptions` - (Required, list) List of encryption types. Valid values are des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, aes-128-gcm (PAN-OS 10.0), and aes-256-gcm (PAN-OS 10.0).<br>- `lifetime_type` - The lifetime type. Valid values are seconds, minutes, hours (the default), and days.<br>- `lifetime_value` - (int) The lifetime value.<br>- `authentication_multiple` - (PAN-OS 7.0+, int) IKEv2 SA reauthentication interval equals authetication-multiple * rekey-lifetime; 0 means reauthentication is disabled<br><br>Example:<pre>{<br>   "AES128_default" = {<br>    dh_groups               = ["group2", "group5"]<br>    authentications         = ["md5", "sha1"]<br>    encryptions             = ["aes-128-cbc", "aes-192-cbc"]<br>    lifetime_type           = "hours"<br>    lifetime_value          = 24<br>    authentication_multiple = 0<br>  }<br>}</pre> | <pre>map(object({<br>    dh_groups               = list(string)<br>    authentications         = list(string)<br>    encryptions             = list(string)<br>    lifetime_type           = optional(string)<br>    lifetime_value          = optional(number)<br>    authentication_multiple = optional(number)<br>  }))</pre> | `{}` | no |
+| <a name="input_ipsec_crypto_profiles"></a> [ipsec\_crypto\_profiles](#input\_ipsec\_crypto\_profiles) | Map of the IPSec crypto profiles, where key is the IPSec crypto profile's name:<br>- `protocol` - (Optional) The protocol. Valid values are esp (the default) or ah<br>- `authentications` - (Required, list) - List of authentication types.<br>- `encryptions` - (Required, list) - List of encryption types. Valid values are des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm, and null. Note that the "gcm" values are only available in PAN-OS 7.0+.<br>- `dh_group` - (Optional) The DH group value. Valid values should start with the string group.<br>- `lifetime_type` - (Optional) The lifetime type. Valid values are seconds, minutes, hours (the default), or days.<br>- `lifetime_value` - (Optional, int) The lifetime value.<br>- `lifesize_type` - (Optional) The lifesize type. Valid values are kb, mb, gb, or tb.<br>- `lifesize_value` - (Optional, int) the lifesize value.<br><br>Example:<pre>{<br>  "AES128_default" = {<br>    protocol        = "esp"<br>    authentications = ["md5", "sha1"]<br>    encryptions     = ["aes-128-cbc", "aes-192-cbc"]<br>    dh_group        = "group5"<br>    lifetime_type   = "hours"<br>    lifetime_value  = 24<br>    lifesize_type   = null<br>    lifesize_value  = null<br>  }<br>}</pre> | <pre>map(object({<br>    protocol        = optional(string, "esp")<br>    authentications = list(string)<br>    encryptions     = list(string)<br>    dh_group        = optional(string)<br>    lifetime_type   = optional(string)<br>    lifetime_value  = optional(number)<br>    lifesize_type   = optional(string)<br>    lifesize_value  = optional(number)<br>  }))</pre> | `{}` | no |
+| <a name="input_ike_gateways"></a> [ike\_gateways](#input\_ike\_gateways) | Map of the IKE gateways, where key is the IKE gateway's name:<br>- `version` - (Optional, PAN-OS 7.0+) The IKE gateway version. Valid values are ikev1, (the default), ikev2, or ikev2-preferred. For PAN-OS 6.1, only ikev1 is acceptable.<br>- `enable_ipv6` - (Optional, PAN-OS 7.0+, bool) Enable IPv6 or not.<br>- `disabled` - (Optional, PAN-OS 7.0+, bool) Set to true to disable.<br>- `peer_ip_type` - (Optional) The peer IP type. Valid values are ip, dynamic, and fqdn (PANOS 8.1+).<br>- `peer_ip_value` - (Optional) The peer IP value.<br>- `interface` - (Required) The interface.<br>- `local_ip_address_type` - (Optional) The local IP address type. Valid values for this are ip, floating-ip, or an empty string (the default) which is None.<br>- `local_ip_address_value` - (Optional) The IP address if local\_ip\_address\_type is set to ip.<br>- `auth_type` - (Optional) The auth type. Valid values are pre-shared-key (the default), or certificate.<br>- `pre_shared_key` - (Optional) The pre-shared key value.<br>- `local_id_type` - (Optional) The local ID type. Valid values are ipaddr, fqdn, ufqdn, keyid, or dn.<br>- `local_id_value` - (Optional) The local ID value.<br>- `peer_id_type` - (Optional) The peer ID type. Valid values are ipaddr, fqdn, ufqdn, keyid, or dn.<br>- `peer_id_value` - (Optional) The peer ID value.<br>- `peer_id_check` - (Optional) Enable peer ID wildcard match for certificate authentication. Valid values are exact or wildcard.<br>- `local_cert` - (Optional) The local certificate name.<br>- `cert_enable_hash_and_url` - (Optional, PAN-OS 7.0+, bool) Set to true to use hash-and-url for local certificate.<br>- `cert_base_url` - (Optional) The host and directory part of URL for local certificates.<br>- `cert_use_management_as_source` - (Optional, PAN-OS 7.0+, bool) Set to true to use management interface IP as source to retrieve http certificates<br>- `cert_permit_payload_mismatch` - (Optional, bool) Set to true to permit peer identification and certificate payload identification mismatch.<br>- `cert_profile` - (Optional) Profile for certificate valdiation during IKE negotiation.<br>- `cert_enable_strict_validation` - (Optional, bool) Set to true to enable strict validation of peer's extended key use.<br>- `enable_passive_mode` - (Optional, bool) Set to true to enable passive mode (responder only).<br>- `enable_nat_traversal` - (Optional, bool) Set to true to enable NAT traversal.<br>- `nat_traversal_keep_alive` - (Optional, int) Sending interval for NAT keep-alive packets (in seconds). For versions 6.1 - 8.1, this param, if specified, should be a multiple of 10 between 10 and 3600 to be valid.<br>- `nat_traversal_enable_udp_checksum` - (Optional, bool) Set to true to enable NAT traversal UDP checksum.<br>- `enable_fragmentation` - (Optional, bool) Set to true to enable fragmentation.<br>- `ikev1_exchange_mode` - (Optional) The IKEv1 exchange mode.<br>- `ikev1_crypto_profile` - (Optional) IKEv1 crypto profile.<br>- `enable_dead_peer_detection` - (Optional, bool) Set to true to enable dead peer detection.<br>- `dead_peer_detection_interval` - (Optional, int) The dead peer detection interval.<br>- `dead_peer_detection_retry` - (Optional, int) Number of retries before disconnection.<br>- `ikev2_crypto_profile` - (Optional, PAN-OS 7.0+) IKEv2 crypto profile.<br>- `ikev2_cookie_validation` - (Optional, PAN-OS 7.0+) Set to true to require cookie.<br>- `enable_liveness_check` - (Optional, , PAN-OS 7.0+bool) Set to true to enable sending empty information liveness check message.<br>- `liveness_check_interval` - (Optional, , PAN-OS 7.0+int) Delay interval before sending probing packets (in seconds).<br><br>Example:<pre>{<br>  "IKE-GW-1" = {<br>    version              = "ikev1"<br>    disabled             = false<br>    peer_ip_type         = "ip"<br>    peer_ip_value        = "5.5.5.5"<br>    interface            = "ethernet1/1"<br>    pre_shared_key       = "test12345"<br>    local_id_type        = "ipaddr"<br>    local_id_value       = "10.1.1.1"<br>    peer_id_type         = "ipaddr"<br>    peer_id_value        = "10.5.1.1"<br>    ikev1_crypto_profile = "AES128_default"<br>  }<br>}</pre> | <pre>map(object({<br>    version                           = optional(string)<br>    enable_ipv6                       = optional(bool)<br>    disabled                          = optional(bool)<br>    peer_ip_type                      = optional(string)<br>    peer_ip_value                     = optional(string)<br>    interface                         = string<br>    local_ip_address_type             = optional(string)<br>    local_ip_address_value            = optional(string)<br>    auth_type                         = optional(string, "pre-shared-key")<br>    pre_shared_key                    = optional(string)<br>    local_id_type                     = optional(string)<br>    local_id_value                    = optional(string)<br>    peer_id_type                      = optional(string)<br>    peer_id_value                     = optional(string)<br>    peer_id_check                     = optional(string)<br>    local_cert                        = optional(string)<br>    cert_enable_hash_and_url          = optional(bool)<br>    cert_base_url                     = optional(string)<br>    cert_use_management_as_source     = optional(bool)<br>    cert_permit_payload_mismatch      = optional(bool)<br>    cert_profile                      = optional(string)<br>    cert_enable_strict_validation     = optional(bool)<br>    enable_passive_mode               = optional(bool)<br>    enable_nat_traversal              = optional(bool)<br>    nat_traversal_keep_alive          = optional(number)<br>    nat_traversal_enable_udp_checksum = optional(bool)<br>    enable_fragmentation              = optional(bool)<br>    ikev1_exchange_mode               = optional(string)<br>    ikev1_crypto_profile              = optional(string)<br>    enable_dead_peer_detection        = optional(bool)<br>    dead_peer_detection_interval      = optional(number)<br>    dead_peer_detection_retry         = optional(number)<br>    ikev2_crypto_profile              = optional(string)<br>    ikev2_cookie_validation           = optional(bool)<br>    enable_liveness_check             = optional(bool)<br>    liveness_check_interval           = optional(number)<br>  }))</pre> | `{}` | no |
+| <a name="input_ipsec_tunnels"></a> [ipsec\_tunnels](#input\_ipsec\_tunnels) | Map of the IPSec tunnels, where key is the IPSec tunnel's name:<br>- `tunnel_interface` - (Required) The tunnel interface.<br>- `anti_replay` - (Optional, bool) Set to true to enable Anti-Replay check on this tunnel.<br>- `enable_ipv6` - (Optional, PAN-OS 7.0+, bool) Set to true to enable IPv6.<br>- `copy_tos` - (Optional, bool) Set to true to copy IP TOS bits from inner packet to IPSec packet (not recommended).<br>- `copy_flow_label` - (Optional, PAN-OS 7.0+, bool) Set to true to copy IPv6 flow label for 6in6 tunnel from inner packet to IPSec packet (not recommended).<br>- `disabled` - (Optional, PAN-OS 7.0+, bool) Set to true to disable this IPSec tunnel.<br>- `type` - (Optional) The type. Valid values are auto-key (the default), manual-key, or global-protect-satellite.<br>- `ak_ike_gateway` - (Optional) IKE gateway name.<br>- `ak_ipsec_crypto_profile` - (Optional) IPSec crypto profile name.<br>- `mk_local_spi` - (Optional) Outbound SPI, hex format.<br>- `mk_remote_spi` - (Optional) Inbound SPI, hex format.<br>- `mk_local_address_ip` - (Optional) Specify exact IP address if interface has multiple addresses.<br>- `mk_local_address_floating_ip` - (Optional) Floating IP address in HA Active-Active configuration.<br>- `mk_protocol` - (Optional) Manual key protocol. Valid valies are esp or ah.<br>- `mk_auth_type` - (Optional) Authentication algorithm. Valid values are md5, sha1, sha256, sha384, sha512, or none.<br>- `mk_auth_key` - (Optional) The auth key for the given auth type.<br>- `mk_esp_encryption_type` - (Optional) The encryption algorithm. Valid values are des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, or null.<br>- `mk_esp_encryption_key` - (Optional) The encryption key.<br>- `gps_interface` - (Optional) Interface to communicate with portal.<br>- `gps_portal_address` - (Optional) GlobalProtect portal address.<br>- `gps_prefer_ipv6` - (Optional, PAN-OS 8.0+, bool) Prefer to register the portal in IPv6. Only applicable to FQDN portal-address.<br>- `gps_interface_ip_ipv4` - (Optional) specify exact IP address if interface has multiple addresses (IPv4).<br>- `gps_interface_ip_ipv6` - (Optional, PAN-OS 8.0+) specify exact IP address if interface has multiple addresses (IPv6).<br>- `gps_interface_floating_ip_ipv4` - (Optional, PAN-OS 7.0+) Floating IPv4 address in HA Active-Active configuration.<br>- `gps_interface_floating_ip_ipv6` - (Optional, PAN-OS 8.0+) Floating IPv6 address in HA Active-Active configuration.<br>- `gps_publish_connected_routes` - (Optional, bool) Set to true to to publish connected and static routes.<br>- `gps_publish_routes` - (Optional, list) Specify list of routes to publish to Global Protect Gateway.<br>- `gps_local_certificate` - (Optional) GlobalProtect satellite certificate file name.<br>- `gps_certificate_profile` - (Optional) Profile for authenticating GlobalProtect gateway certificates.<br>- `enable_tunnel_monitor` - (Optional, bool) Enable tunnel monitoring on this tunnel.<br>- `tunnel_monitor_destination_ip` - (Optional) Destination IP to send ICMP probe.<br>- `tunnel_monitor_source_ip` - (Optional) Source IP to send ICMP probe<br>- `tunnel_monitor_profile` - (Optional) Tunnel monitor profile.<br>- `tunnel_monitor_proxy_id` - (Optional, PAN-OS 7.0+) Which proxy-id (or proxy-id-v6) the monitoring traffic will use.<br><br>Example:<pre>{<br>  "some_tunnel" = {<br>    virtual_router                = "internal"<br>    tunnel_interface              = "tunnel.42"<br>    type                          = "auto-key"<br>    disabled                      = false<br>    ak_ike_gateway                = "IKE-GW-1"<br>    ak_ipsec_crypto_profile       = "AES128_DH14"<br>    anti_replay                   = false<br>    copy_flow_label               = false<br>    enable_tunnel_monitor         = false<br>    tunnel_monitor_destination_ip = null<br>    tunnel_monitor_source_ip      = null<br>    tunnel_monitor_profile        = null<br>    tunnel_monitor_proxy_id       = null<br>    proxy_subnets                 = "example1,10.10.10.0/24,10.10.20.0/24;example2,10.10.10.0/24,10.10.30.0/24"<br>  }<br>}</pre> | <pre>map(object({<br>    tunnel_interface               = string<br>    anti_replay                    = optional(bool)<br>    enable_ipv6                    = optional(bool)<br>    copy_tos                       = optional(bool)<br>    copy_flow_label                = optional(bool)<br>    disabled                       = optional(bool)<br>    type                           = optional(string, "auto-key")<br>    ak_ike_gateway                 = optional(string)<br>    ak_ipsec_crypto_profile        = optional(string)<br>    mk_local_spi                   = optional(string)<br>    mk_remote_spi                  = optional(string)<br>    mk_local_address_ip            = optional(string)<br>    mk_local_address_floating_ip   = optional(string)<br>    mk_protocol                    = optional(string)<br>    mk_auth_type                   = optional(string)<br>    mk_auth_key                    = optional(string)<br>    mk_esp_encryption_type         = optional(string)<br>    mk_esp_encryption_key          = optional(string)<br>    gps_interface                  = optional(string)<br>    gps_portal_address             = optional(string)<br>    gps_prefer_ipv6                = optional(bool)<br>    gps_interface_ip_ipv4          = optional(string)<br>    gps_interface_ip_ipv6          = optional(string)<br>    gps_interface_floating_ip_ipv4 = optional(string)<br>    gps_interface_floating_ip_ipv6 = optional(string)<br>    gps_publish_connected_routes   = optional(bool)<br>    gps_publish_routes             = optional(list(string))<br>    gps_local_certificate          = optional(string)<br>    gps_certificate_profile        = optional(string)<br>    enable_tunnel_monitor          = optional(bool)<br>    tunnel_monitor_destination_ip  = optional(string)<br>    tunnel_monitor_source_ip       = optional(string)<br>    tunnel_monitor_profile         = optional(string)<br>    tunnel_monitor_proxy_id        = optional(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_ipsec_tunnel_proxies"></a> [ipsec\_tunnel\_proxies](#input\_ipsec\_tunnel\_proxies) | Map of the IPSec tunnel proxy, where key is the IPSec tunnel proxy's name:<br>- `ipsec_tunnel` - (Required) The auto key IPSec tunnel to attach this proxy ID to.<br>- `local` - (Optional) IP subnet or IP address represents local network.<br>- `remote` - (Optional) IP subnet or IP address represents remote network.<br>- `protocol_any` - (Optional, bool) Set to true for any IP protocol.<br>- `protocol_number` - (Optional, int) IP protocol number.<br>- `protocol_tcp_local` - (Optional, int) Local TCP port number.<br>- `protocol_tcp_remote` - (Optional, int) Remote TCP port number.<br>- `protocol_udp_local` - (Optional, int) Local UDP port number.<br>- `protocol_udp_remote` - (Optional, int) Remote UDP port number.<br><br>Example:<pre>{<br>  ipsec_tunnel = "some_tunnel"<br>}</pre> | <pre>map(object({<br>    ipsec_tunnel        = string<br>    local               = optional(string)<br>    remote              = optional(string)<br>    protocol_any        = optional(bool, true)<br>    protocol_number     = optional(number)<br>    protocol_tcp_local  = optional(number)<br>    protocol_tcp_remote = optional(number)<br>    protocol_udp_local  = optional(number)<br>    protocol_udp_remote = optional(number)<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ike_crypto_profiles"></a> [ike\_crypto\_profiles](#output\_ike\_crypto\_profiles) | n/a |
+| <a name="output_panorama_ipsec_crypto_profiles"></a> [panorama\_ipsec\_crypto\_profiles](#output\_panorama\_ipsec\_crypto\_profiles) | n/a |
+| <a name="output_ipsec_crypto_profiles"></a> [ipsec\_crypto\_profiles](#output\_ipsec\_crypto\_profiles) | n/a |
+| <a name="output_panorama_ike_gateways"></a> [panorama\_ike\_gateways](#output\_panorama\_ike\_gateways) | n/a |
+| <a name="output_ike_gateways"></a> [ike\_gateways](#output\_ike\_gateways) | n/a |
+| <a name="output_panorama_ipsec_tunnels"></a> [panorama\_ipsec\_tunnels](#output\_panorama\_ipsec\_tunnels) | n/a |
+| <a name="output_ipsec_tunnels"></a> [ipsec\_tunnels](#output\_ipsec\_tunnels) | n/a |
+| <a name="output_panorama_ipsec_tunnel_proxy_ids_ipv4"></a> [panorama\_ipsec\_tunnel\_proxy\_ids\_ipv4](#output\_panorama\_ipsec\_tunnel\_proxy\_ids\_ipv4) | n/a |
+| <a name="output_ipsec_tunnel_proxy_ids_ipv4"></a> [ipsec\_tunnel\_proxy\_ids\_ipv4](#output\_ipsec\_tunnel\_proxy\_ids\_ipv4) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ipsec/main.tf
+++ b/modules/ipsec/main.tf
@@ -1,0 +1,308 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_ike_crypto_profile" "this" {
+  for_each = var.ike_crypto_profiles
+
+  template       = local.mode_map[var.mode] == 0 ? (var.template_stack == "" ? var.template : null) : null
+  template_stack = local.mode_map[var.mode] == 0 ? var.template_stack == "" ? null : var.template_stack : null
+
+  name                    = each.key
+  dh_groups               = each.value.dh_groups
+  authentications         = each.value.authentications
+  encryptions             = each.value.encryptions
+  lifetime_type           = each.value.lifetime_type
+  lifetime_value          = each.value.lifetime_value
+  authentication_multiple = each.value.authentication_multiple
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_ipsec_crypto_profile" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.ipsec_crypto_profiles : {}
+
+  template       = var.template_stack == "" ? var.template : null
+  template_stack = var.template_stack == "" ? null : var.template_stack
+
+  name            = each.key
+  protocol        = each.value.protocol
+  dh_group        = each.value.dh_group
+  authentications = each.value.authentications
+  encryptions     = each.value.encryptions
+  lifetime_type   = each.value.lifetime_type
+  lifetime_value  = each.value.lifetime_value
+  lifesize_type   = each.value.lifesize_type
+  lifesize_value  = each.value.lifesize_value
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_ipsec_crypto_profile" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.ipsec_crypto_profiles : {}
+
+  name            = each.key
+  protocol        = each.value.protocol
+  dh_group        = each.value.dh_group
+  authentications = each.value.authentications
+  encryptions     = each.value.encryptions
+  lifetime_type   = each.value.lifetime_type
+  lifetime_value  = each.value.lifetime_value
+  lifesize_type   = each.value.lifesize_type
+  lifesize_value  = each.value.lifesize_value
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_ike_gateway" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.ike_gateways : {}
+
+  template       = var.template_stack == "" ? var.template : null
+  template_stack = var.template_stack == "" ? null : var.template_stack
+
+  name                              = each.key
+  version                           = each.value.version
+  enable_ipv6                       = each.value.enable_ipv6
+  disabled                          = each.value.disabled
+  peer_ip_type                      = each.value.peer_ip_type
+  peer_ip_value                     = each.value.peer_ip_value
+  interface                         = each.value.interface
+  local_ip_address_type             = each.value.local_ip_address_type
+  local_ip_address_value            = each.value.local_ip_address_value
+  auth_type                         = each.value.auth_type
+  pre_shared_key                    = each.value.pre_shared_key
+  local_id_type                     = each.value.local_id_type
+  local_id_value                    = each.value.local_id_value
+  peer_id_type                      = each.value.peer_id_type
+  peer_id_value                     = each.value.peer_id_value
+  peer_id_check                     = each.value.peer_id_check
+  local_cert                        = each.value.local_cert
+  cert_enable_hash_and_url          = each.value.cert_enable_hash_and_url
+  cert_base_url                     = each.value.cert_base_url
+  cert_use_management_as_source     = each.value.cert_use_management_as_source
+  cert_permit_payload_mismatch      = each.value.cert_permit_payload_mismatch
+  cert_profile                      = each.value.cert_profile
+  cert_enable_strict_validation     = each.value.cert_enable_strict_validation
+  enable_passive_mode               = each.value.enable_passive_mode
+  enable_nat_traversal              = each.value.enable_nat_traversal
+  nat_traversal_keep_alive          = each.value.nat_traversal_keep_alive
+  nat_traversal_enable_udp_checksum = each.value.nat_traversal_enable_udp_checksum
+  enable_fragmentation              = each.value.enable_fragmentation
+  ikev1_exchange_mode               = each.value.ikev1_exchange_mode
+  ikev1_crypto_profile              = each.value.ikev1_crypto_profile
+  enable_dead_peer_detection        = each.value.enable_dead_peer_detection
+  dead_peer_detection_interval      = each.value.dead_peer_detection_interval
+  dead_peer_detection_retry         = each.value.dead_peer_detection_retry
+  ikev2_crypto_profile              = each.value.ikev2_crypto_profile
+  ikev2_cookie_validation           = each.value.ikev2_cookie_validation
+  enable_liveness_check             = each.value.enable_liveness_check
+  liveness_check_interval           = each.value.liveness_check_interval
+
+  depends_on = [
+    panos_ike_crypto_profile.this,
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_ike_gateway" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.ike_gateways : {}
+
+  name                              = each.key
+  version                           = each.value.version
+  enable_ipv6                       = each.value.enable_ipv6
+  disabled                          = each.value.disabled
+  peer_ip_type                      = each.value.peer_ip_type
+  peer_ip_value                     = each.value.peer_ip_value
+  interface                         = each.value.interface
+  local_ip_address_type             = each.value.local_ip_address_type
+  local_ip_address_value            = each.value.local_ip_address_value
+  auth_type                         = each.value.auth_type
+  pre_shared_key                    = each.value.pre_shared_key
+  local_id_type                     = each.value.local_id_type
+  local_id_value                    = each.value.local_id_value
+  peer_id_type                      = each.value.peer_id_type
+  peer_id_value                     = each.value.peer_id_value
+  peer_id_check                     = each.value.peer_id_check
+  local_cert                        = each.value.local_cert
+  cert_enable_hash_and_url          = each.value.cert_enable_hash_and_url
+  cert_base_url                     = each.value.cert_base_url
+  cert_use_management_as_source     = each.value.cert_use_management_as_source
+  cert_permit_payload_mismatch      = each.value.cert_permit_payload_mismatch
+  cert_profile                      = each.value.cert_profile
+  cert_enable_strict_validation     = each.value.cert_enable_strict_validation
+  enable_passive_mode               = each.value.enable_passive_mode
+  enable_nat_traversal              = each.value.enable_nat_traversal
+  nat_traversal_keep_alive          = each.value.nat_traversal_keep_alive
+  nat_traversal_enable_udp_checksum = each.value.nat_traversal_enable_udp_checksum
+  enable_fragmentation              = each.value.enable_fragmentation
+  ikev1_exchange_mode               = each.value.ikev1_exchange_mode
+  ikev1_crypto_profile              = each.value.ikev1_crypto_profile
+  enable_dead_peer_detection        = each.value.enable_dead_peer_detection
+  dead_peer_detection_interval      = each.value.dead_peer_detection_interval
+  dead_peer_detection_retry         = each.value.dead_peer_detection_retry
+  ikev2_crypto_profile              = each.value.ikev2_crypto_profile
+  ikev2_cookie_validation           = each.value.ikev2_cookie_validation
+  enable_liveness_check             = each.value.enable_liveness_check
+  liveness_check_interval           = each.value.liveness_check_interval
+
+  depends_on = [
+    panos_ike_crypto_profile.this
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_ipsec_tunnel" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.ipsec_tunnels : {}
+
+  template = var.template
+  ### an argument named "template_stack" is not expected here
+
+  name                           = each.key
+  tunnel_interface               = each.value.tunnel_interface
+  anti_replay                    = each.value.anti_replay
+  enable_ipv6                    = each.value.enable_ipv6
+  copy_tos                       = each.value.copy_tos
+  copy_flow_label                = each.value.copy_flow_label
+  disabled                       = each.value.disabled
+  type                           = each.value.type
+  ak_ike_gateway                 = each.value.ak_ike_gateway
+  ak_ipsec_crypto_profile        = each.value.ak_ipsec_crypto_profile
+  mk_local_spi                   = each.value.mk_local_spi
+  mk_remote_spi                  = each.value.mk_remote_spi
+  mk_local_address_ip            = each.value.mk_local_address_ip
+  mk_local_address_floating_ip   = each.value.mk_local_address_floating_ip
+  mk_protocol                    = each.value.mk_protocol
+  mk_auth_type                   = each.value.mk_auth_type
+  mk_auth_key                    = each.value.mk_auth_key
+  mk_esp_encryption_type         = each.value.mk_esp_encryption_type
+  mk_esp_encryption_key          = each.value.mk_esp_encryption_key
+  gps_interface                  = each.value.gps_interface
+  gps_portal_address             = each.value.gps_portal_address
+  gps_prefer_ipv6                = each.value.gps_prefer_ipv6
+  gps_interface_ip_ipv4          = each.value.gps_interface_ip_ipv4
+  gps_interface_ip_ipv6          = each.value.gps_interface_ip_ipv6
+  gps_interface_floating_ip_ipv4 = each.value.gps_interface_floating_ip_ipv4
+  gps_interface_floating_ip_ipv6 = each.value.gps_interface_floating_ip_ipv6
+  gps_publish_connected_routes   = each.value.gps_publish_connected_routes
+  gps_publish_routes             = each.value.gps_publish_routes
+  gps_local_certificate          = each.value.gps_local_certificate
+  gps_certificate_profile        = each.value.gps_certificate_profile
+  enable_tunnel_monitor          = each.value.enable_tunnel_monitor
+  tunnel_monitor_destination_ip  = each.value.tunnel_monitor_destination_ip
+  tunnel_monitor_source_ip       = each.value.tunnel_monitor_source_ip
+  tunnel_monitor_profile         = each.value.tunnel_monitor_profile
+  tunnel_monitor_proxy_id        = each.value.tunnel_monitor_proxy_id
+
+  depends_on = [
+    panos_panorama_ike_gateway.this,
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_ipsec_tunnel" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.ipsec_tunnels : {}
+
+  name                           = each.key
+  tunnel_interface               = each.value.tunnel_interface
+  anti_replay                    = each.value.anti_replay
+  enable_ipv6                    = each.value.enable_ipv6
+  copy_tos                       = each.value.copy_tos
+  copy_flow_label                = each.value.copy_flow_label
+  disabled                       = each.value.disabled
+  type                           = each.value.type
+  ak_ike_gateway                 = each.value.ak_ike_gateway
+  ak_ipsec_crypto_profile        = each.value.ak_ipsec_crypto_profile
+  mk_local_spi                   = each.value.mk_local_spi
+  mk_remote_spi                  = each.value.mk_remote_spi
+  mk_local_address_ip            = each.value.mk_local_address_ip
+  mk_local_address_floating_ip   = each.value.mk_local_address_floating_ip
+  mk_protocol                    = each.value.mk_protocol
+  mk_auth_type                   = each.value.mk_auth_type
+  mk_auth_key                    = each.value.mk_auth_key
+  mk_esp_encryption_type         = each.value.mk_esp_encryption_type
+  mk_esp_encryption_key          = each.value.mk_esp_encryption_key
+  gps_interface                  = each.value.gps_interface
+  gps_portal_address             = each.value.gps_portal_address
+  gps_prefer_ipv6                = each.value.gps_prefer_ipv6
+  gps_interface_ip_ipv4          = each.value.gps_interface_ip_ipv4
+  gps_interface_ip_ipv6          = each.value.gps_interface_ip_ipv6
+  gps_interface_floating_ip_ipv4 = each.value.gps_interface_floating_ip_ipv4
+  gps_interface_floating_ip_ipv6 = each.value.gps_interface_floating_ip_ipv6
+  gps_publish_connected_routes   = each.value.gps_publish_connected_routes
+  gps_publish_routes             = each.value.gps_publish_routes
+  gps_local_certificate          = each.value.gps_local_certificate
+  gps_certificate_profile        = each.value.gps_certificate_profile
+  enable_tunnel_monitor          = each.value.enable_tunnel_monitor
+  tunnel_monitor_destination_ip  = each.value.tunnel_monitor_destination_ip
+  tunnel_monitor_source_ip       = each.value.tunnel_monitor_source_ip
+  tunnel_monitor_profile         = each.value.tunnel_monitor_profile
+  tunnel_monitor_proxy_id        = each.value.tunnel_monitor_proxy_id
+
+  depends_on = [
+    panos_ike_gateway.this,
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_ipsec_tunnel_proxy_id_ipv4" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.ipsec_tunnel_proxies : {}
+
+  template = var.template
+  ### an argument named "template_stack" is not expected here
+
+  name                = each.key
+  ipsec_tunnel        = each.value.ipsec_tunnel
+  local               = each.value.local
+  remote              = each.value.remote
+  protocol_any        = each.value.protocol_any
+  protocol_number     = each.value.protocol_number
+  protocol_tcp_local  = each.value.protocol_tcp_local
+  protocol_tcp_remote = each.value.protocol_tcp_remote
+  protocol_udp_local  = each.value.protocol_udp_local
+  protocol_udp_remote = each.value.protocol_udp_remote
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_ipsec_tunnel_proxy_id_ipv4" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.ipsec_tunnel_proxies : {}
+
+  name                = each.key
+  ipsec_tunnel        = each.value.ipsec_tunnel
+  local               = each.value.local
+  remote              = each.value.remote
+  protocol_any        = each.value.protocol_any
+  protocol_number     = each.value.protocol_number
+  protocol_tcp_local  = each.value.protocol_tcp_local
+  protocol_tcp_remote = each.value.protocol_tcp_remote
+  protocol_udp_local  = each.value.protocol_udp_local
+  protocol_udp_remote = each.value.protocol_udp_remote
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/ipsec/main_test.go
+++ b/modules/ipsec/main_test.go
@@ -1,0 +1,11 @@
+package ipsec
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/ipsec/outputs.tf
+++ b/modules/ipsec/outputs.tf
@@ -1,0 +1,35 @@
+output "ike_crypto_profiles" {
+  value = panos_ike_crypto_profile.this
+}
+
+output "panorama_ipsec_crypto_profiles" {
+  value = panos_panorama_ipsec_crypto_profile.this
+}
+
+output "ipsec_crypto_profiles" {
+  value = panos_ipsec_crypto_profile.this
+}
+
+output "panorama_ike_gateways" {
+  value = panos_panorama_ike_gateway.this
+}
+
+output "ike_gateways" {
+  value = panos_ike_gateway.this
+}
+
+output "panorama_ipsec_tunnels" {
+  value = panos_panorama_ipsec_tunnel.this
+}
+
+output "ipsec_tunnels" {
+  value = panos_ipsec_tunnel.this
+}
+
+output "panorama_ipsec_tunnel_proxy_ids_ipv4" {
+  value = panos_panorama_ipsec_tunnel_proxy_id_ipv4.this
+}
+
+output "ipsec_tunnel_proxy_ids_ipv4" {
+  value = panos_ipsec_tunnel_proxy_id_ipv4.this
+}

--- a/modules/ipsec/variables.tf
+++ b/modules/ipsec/variables.tf
@@ -1,0 +1,381 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "template" {
+  description = "The template name."
+  default     = "default"
+  type        = string
+}
+
+variable "template_stack" {
+  description = "The template stack name."
+  default     = ""
+  type        = string
+}
+
+variable "ike_crypto_profiles" {
+  description = <<-EOF
+  Map of the IKE crypto profiles, where key is the IKE crypto profile's name:
+  - `dh_groups` - (Required, list) List of DH Group entries. Values should have a prefix if group.
+  - `authentications` - (Required, list) List of authentication types. This c
+  - `encryptions` - (Required, list) List of encryption types. Valid values are des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, aes-128-gcm (PAN-OS 10.0), and aes-256-gcm (PAN-OS 10.0).
+  - `lifetime_type` - The lifetime type. Valid values are seconds, minutes, hours (the default), and days.
+  - `lifetime_value` - (int) The lifetime value.
+  - `authentication_multiple` - (PAN-OS 7.0+, int) IKEv2 SA reauthentication interval equals authetication-multiple * rekey-lifetime; 0 means reauthentication is disabled
+
+  Example:
+  ```
+  {
+     "AES128_default" = {
+      dh_groups               = ["group2", "group5"]
+      authentications         = ["md5", "sha1"]
+      encryptions             = ["aes-128-cbc", "aes-192-cbc"]
+      lifetime_type           = "hours"
+      lifetime_value          = 24
+      authentication_multiple = 0
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    dh_groups               = list(string)
+    authentications         = list(string)
+    encryptions             = list(string)
+    lifetime_type           = optional(string)
+    lifetime_value          = optional(number)
+    authentication_multiple = optional(number)
+  }))
+  validation {
+    condition     = alltrue([for ike_crypto_profile in var.ike_crypto_profiles : contains(["seconds", "minutes", "hours", "days"], ike_crypto_profile.lifetime_type)])
+    error_message = "Valid values for the lifetime type are `seconds`, `minutes`, `hours` (the default), and `days`"
+  }
+  validation {
+    condition     = alltrue([for ike_crypto_profile in var.ike_crypto_profiles : length(setsubtract(ike_crypto_profile.encryptions, ["des", "3des", "aes-128-cbc", "aes-192-cbc", "aes-256-cbc", "aes-128-gcm", "aes-256-gcm"])) == 0])
+    error_message = "Valid values for the encryptions are `des`, `3des`, `aes-128-cbc`, `aes-192-cbc`, `aes-256-cbc`, `aes-128-gcm` (PAN-OS 10.0), and `aes-256-gcm`"
+  }
+}
+variable "ipsec_crypto_profiles" {
+  description = <<-EOF
+  Map of the IPSec crypto profiles, where key is the IPSec crypto profile's name:
+  - `protocol` - (Optional) The protocol. Valid values are esp (the default) or ah
+  - `authentications` - (Required, list) - List of authentication types.
+  - `encryptions` - (Required, list) - List of encryption types. Valid values are des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm, and null. Note that the "gcm" values are only available in PAN-OS 7.0+.
+  - `dh_group` - (Optional) The DH group value. Valid values should start with the string group.
+  - `lifetime_type` - (Optional) The lifetime type. Valid values are seconds, minutes, hours (the default), or days.
+  - `lifetime_value` - (Optional, int) The lifetime value.
+  - `lifesize_type` - (Optional) The lifesize type. Valid values are kb, mb, gb, or tb.
+  - `lifesize_value` - (Optional, int) the lifesize value.
+
+  Example:
+  ```
+  {
+    "AES128_default" = {
+      protocol        = "esp"
+      authentications = ["md5", "sha1"]
+      encryptions     = ["aes-128-cbc", "aes-192-cbc"]
+      dh_group        = "group5"
+      lifetime_type   = "hours"
+      lifetime_value  = 24
+      lifesize_type   = null
+      lifesize_value  = null
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    protocol        = optional(string, "esp")
+    authentications = list(string)
+    encryptions     = list(string)
+    dh_group        = optional(string)
+    lifetime_type   = optional(string)
+    lifetime_value  = optional(number)
+    lifesize_type   = optional(string)
+    lifesize_value  = optional(number)
+  }))
+  validation {
+    condition     = alltrue([for ipsec_crypto_profile in var.ipsec_crypto_profiles : contains(["esp", "ah"], ipsec_crypto_profile.protocol)])
+    error_message = "Valid values for the protocol are `esp` and `ah`"
+  }
+  validation {
+    condition     = alltrue([for ipsec_crypto_profile in var.ipsec_crypto_profiles : contains(["seconds", "minutes", "hours", "days"], ipsec_crypto_profile.lifetime_type)])
+    error_message = "Valid values for the lifetime type are `seconds`, `minutes`, `hours` (the default), and `days`"
+  }
+  validation {
+    condition     = alltrue([for ipsec_crypto_profile in var.ipsec_crypto_profiles : contains(["kb", "mb", "gb", "tb"], coalesce(ipsec_crypto_profile.lifesize_type, "kb"))])
+    error_message = "Valid values for the lifesize type are `kb`, `mb`, `gb`, or `tb`"
+  }
+  validation {
+    condition     = alltrue([for ipsec_crypto_profile in var.ipsec_crypto_profiles : length(setsubtract(ipsec_crypto_profile.encryptions, ["des", "3des", "aes-128-cbc", "aes-192-cbc", "aes-256-cbc", "aes-128-gcm", "aes-256-gcm"])) == 0])
+    error_message = "Valid values for the encryptions are `des`, `3des`, `aes-128-cbc`, `aes-192-cbc`, `aes-256-cbc`, `aes-128-gcm` and `aes-256-gcm`"
+  }
+}
+variable "ike_gateways" {
+  description = <<-EOF
+  Map of the IKE gateways, where key is the IKE gateway's name:
+  - `version` - (Optional, PAN-OS 7.0+) The IKE gateway version. Valid values are ikev1, (the default), ikev2, or ikev2-preferred. For PAN-OS 6.1, only ikev1 is acceptable.
+  - `enable_ipv6` - (Optional, PAN-OS 7.0+, bool) Enable IPv6 or not.
+  - `disabled` - (Optional, PAN-OS 7.0+, bool) Set to true to disable.
+  - `peer_ip_type` - (Optional) The peer IP type. Valid values are ip, dynamic, and fqdn (PANOS 8.1+).
+  - `peer_ip_value` - (Optional) The peer IP value.
+  - `interface` - (Required) The interface.
+  - `local_ip_address_type` - (Optional) The local IP address type. Valid values for this are ip, floating-ip, or an empty string (the default) which is None.
+  - `local_ip_address_value` - (Optional) The IP address if local_ip_address_type is set to ip.
+  - `auth_type` - (Optional) The auth type. Valid values are pre-shared-key (the default), or certificate.
+  - `pre_shared_key` - (Optional) The pre-shared key value.
+  - `local_id_type` - (Optional) The local ID type. Valid values are ipaddr, fqdn, ufqdn, keyid, or dn.
+  - `local_id_value` - (Optional) The local ID value.
+  - `peer_id_type` - (Optional) The peer ID type. Valid values are ipaddr, fqdn, ufqdn, keyid, or dn.
+  - `peer_id_value` - (Optional) The peer ID value.
+  - `peer_id_check` - (Optional) Enable peer ID wildcard match for certificate authentication. Valid values are exact or wildcard.
+  - `local_cert` - (Optional) The local certificate name.
+  - `cert_enable_hash_and_url` - (Optional, PAN-OS 7.0+, bool) Set to true to use hash-and-url for local certificate.
+  - `cert_base_url` - (Optional) The host and directory part of URL for local certificates.
+  - `cert_use_management_as_source` - (Optional, PAN-OS 7.0+, bool) Set to true to use management interface IP as source to retrieve http certificates
+  - `cert_permit_payload_mismatch` - (Optional, bool) Set to true to permit peer identification and certificate payload identification mismatch.
+  - `cert_profile` - (Optional) Profile for certificate valdiation during IKE negotiation.
+  - `cert_enable_strict_validation` - (Optional, bool) Set to true to enable strict validation of peer's extended key use.
+  - `enable_passive_mode` - (Optional, bool) Set to true to enable passive mode (responder only).
+  - `enable_nat_traversal` - (Optional, bool) Set to true to enable NAT traversal.
+  - `nat_traversal_keep_alive` - (Optional, int) Sending interval for NAT keep-alive packets (in seconds). For versions 6.1 - 8.1, this param, if specified, should be a multiple of 10 between 10 and 3600 to be valid.
+  - `nat_traversal_enable_udp_checksum` - (Optional, bool) Set to true to enable NAT traversal UDP checksum.
+  - `enable_fragmentation` - (Optional, bool) Set to true to enable fragmentation.
+  - `ikev1_exchange_mode` - (Optional) The IKEv1 exchange mode.
+  - `ikev1_crypto_profile` - (Optional) IKEv1 crypto profile.
+  - `enable_dead_peer_detection` - (Optional, bool) Set to true to enable dead peer detection.
+  - `dead_peer_detection_interval` - (Optional, int) The dead peer detection interval.
+  - `dead_peer_detection_retry` - (Optional, int) Number of retries before disconnection.
+  - `ikev2_crypto_profile` - (Optional, PAN-OS 7.0+) IKEv2 crypto profile.
+  - `ikev2_cookie_validation` - (Optional, PAN-OS 7.0+) Set to true to require cookie.
+  - `enable_liveness_check` - (Optional, , PAN-OS 7.0+bool) Set to true to enable sending empty information liveness check message.
+  - `liveness_check_interval` - (Optional, , PAN-OS 7.0+int) Delay interval before sending probing packets (in seconds).
+
+  Example:
+  ```
+  {
+    "IKE-GW-1" = {
+      version              = "ikev1"
+      disabled             = false
+      peer_ip_type         = "ip"
+      peer_ip_value        = "5.5.5.5"
+      interface            = "ethernet1/1"
+      pre_shared_key       = "test12345"
+      local_id_type        = "ipaddr"
+      local_id_value       = "10.1.1.1"
+      peer_id_type         = "ipaddr"
+      peer_id_value        = "10.5.1.1"
+      ikev1_crypto_profile = "AES128_default"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    version                           = optional(string)
+    enable_ipv6                       = optional(bool)
+    disabled                          = optional(bool)
+    peer_ip_type                      = optional(string)
+    peer_ip_value                     = optional(string)
+    interface                         = string
+    local_ip_address_type             = optional(string)
+    local_ip_address_value            = optional(string)
+    auth_type                         = optional(string, "pre-shared-key")
+    pre_shared_key                    = optional(string)
+    local_id_type                     = optional(string)
+    local_id_value                    = optional(string)
+    peer_id_type                      = optional(string)
+    peer_id_value                     = optional(string)
+    peer_id_check                     = optional(string)
+    local_cert                        = optional(string)
+    cert_enable_hash_and_url          = optional(bool)
+    cert_base_url                     = optional(string)
+    cert_use_management_as_source     = optional(bool)
+    cert_permit_payload_mismatch      = optional(bool)
+    cert_profile                      = optional(string)
+    cert_enable_strict_validation     = optional(bool)
+    enable_passive_mode               = optional(bool)
+    enable_nat_traversal              = optional(bool)
+    nat_traversal_keep_alive          = optional(number)
+    nat_traversal_enable_udp_checksum = optional(bool)
+    enable_fragmentation              = optional(bool)
+    ikev1_exchange_mode               = optional(string)
+    ikev1_crypto_profile              = optional(string)
+    enable_dead_peer_detection        = optional(bool)
+    dead_peer_detection_interval      = optional(number)
+    dead_peer_detection_retry         = optional(number)
+    ikev2_crypto_profile              = optional(string)
+    ikev2_cookie_validation           = optional(bool)
+    enable_liveness_check             = optional(bool)
+    liveness_check_interval           = optional(number)
+  }))
+  validation {
+    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ikev1", "ikev2", "ikev2-preferred"], ike_gateway.version)])
+    error_message = "Valid values for IKE gateway version are `ikev1`, `ikev2`, `ikev2-preferred`"
+  }
+  validation {
+    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn"], coalesce(ike_gateway.peer_id_type, "ipaddr"))])
+    error_message = "If set, valid values for peer ID type are `ipaddr`, `fqdn`, `ufqdn`, `keyid`, or `dn`."
+  }
+  validation {
+    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn"], coalesce(ike_gateway.local_id_type, "ipaddr"))])
+    error_message = "If set, valid values for local ID type are `ipaddr`, `fqdn`, `ufqdn`, `keyid`, or `dn`"
+  }
+  validation {
+    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["pre-shared-key", "certificate"], ike_gateway.auth_type)])
+    error_message = "Valid values for auth type are `pre-shared-key` (the default), or `certificate`"
+  }
+}
+variable "ipsec_tunnels" {
+  description = <<-EOF
+  Map of the IPSec tunnels, where key is the IPSec tunnel's name:
+  - `tunnel_interface` - (Required) The tunnel interface.
+  - `anti_replay` - (Optional, bool) Set to true to enable Anti-Replay check on this tunnel.
+  - `enable_ipv6` - (Optional, PAN-OS 7.0+, bool) Set to true to enable IPv6.
+  - `copy_tos` - (Optional, bool) Set to true to copy IP TOS bits from inner packet to IPSec packet (not recommended).
+  - `copy_flow_label` - (Optional, PAN-OS 7.0+, bool) Set to true to copy IPv6 flow label for 6in6 tunnel from inner packet to IPSec packet (not recommended).
+  - `disabled` - (Optional, PAN-OS 7.0+, bool) Set to true to disable this IPSec tunnel.
+  - `type` - (Optional) The type. Valid values are auto-key (the default), manual-key, or global-protect-satellite.
+  - `ak_ike_gateway` - (Optional) IKE gateway name.
+  - `ak_ipsec_crypto_profile` - (Optional) IPSec crypto profile name.
+  - `mk_local_spi` - (Optional) Outbound SPI, hex format.
+  - `mk_remote_spi` - (Optional) Inbound SPI, hex format.
+  - `mk_local_address_ip` - (Optional) Specify exact IP address if interface has multiple addresses.
+  - `mk_local_address_floating_ip` - (Optional) Floating IP address in HA Active-Active configuration.
+  - `mk_protocol` - (Optional) Manual key protocol. Valid valies are esp or ah.
+  - `mk_auth_type` - (Optional) Authentication algorithm. Valid values are md5, sha1, sha256, sha384, sha512, or none.
+  - `mk_auth_key` - (Optional) The auth key for the given auth type.
+  - `mk_esp_encryption_type` - (Optional) The encryption algorithm. Valid values are des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, or null.
+  - `mk_esp_encryption_key` - (Optional) The encryption key.
+  - `gps_interface` - (Optional) Interface to communicate with portal.
+  - `gps_portal_address` - (Optional) GlobalProtect portal address.
+  - `gps_prefer_ipv6` - (Optional, PAN-OS 8.0+, bool) Prefer to register the portal in IPv6. Only applicable to FQDN portal-address.
+  - `gps_interface_ip_ipv4` - (Optional) specify exact IP address if interface has multiple addresses (IPv4).
+  - `gps_interface_ip_ipv6` - (Optional, PAN-OS 8.0+) specify exact IP address if interface has multiple addresses (IPv6).
+  - `gps_interface_floating_ip_ipv4` - (Optional, PAN-OS 7.0+) Floating IPv4 address in HA Active-Active configuration.
+  - `gps_interface_floating_ip_ipv6` - (Optional, PAN-OS 8.0+) Floating IPv6 address in HA Active-Active configuration.
+  - `gps_publish_connected_routes` - (Optional, bool) Set to true to to publish connected and static routes.
+  - `gps_publish_routes` - (Optional, list) Specify list of routes to publish to Global Protect Gateway.
+  - `gps_local_certificate` - (Optional) GlobalProtect satellite certificate file name.
+  - `gps_certificate_profile` - (Optional) Profile for authenticating GlobalProtect gateway certificates.
+  - `enable_tunnel_monitor` - (Optional, bool) Enable tunnel monitoring on this tunnel.
+  - `tunnel_monitor_destination_ip` - (Optional) Destination IP to send ICMP probe.
+  - `tunnel_monitor_source_ip` - (Optional) Source IP to send ICMP probe
+  - `tunnel_monitor_profile` - (Optional) Tunnel monitor profile.
+  - `tunnel_monitor_proxy_id` - (Optional, PAN-OS 7.0+) Which proxy-id (or proxy-id-v6) the monitoring traffic will use.
+
+  Example:
+  ```
+  {
+    "some_tunnel" = {
+      virtual_router                = "internal"
+      tunnel_interface              = "tunnel.42"
+      type                          = "auto-key"
+      disabled                      = false
+      ak_ike_gateway                = "IKE-GW-1"
+      ak_ipsec_crypto_profile       = "AES128_DH14"
+      anti_replay                   = false
+      copy_flow_label               = false
+      enable_tunnel_monitor         = false
+      tunnel_monitor_destination_ip = null
+      tunnel_monitor_source_ip      = null
+      tunnel_monitor_profile        = null
+      tunnel_monitor_proxy_id       = null
+      proxy_subnets                 = "example1,10.10.10.0/24,10.10.20.0/24;example2,10.10.10.0/24,10.10.30.0/24"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    tunnel_interface               = string
+    anti_replay                    = optional(bool)
+    enable_ipv6                    = optional(bool)
+    copy_tos                       = optional(bool)
+    copy_flow_label                = optional(bool)
+    disabled                       = optional(bool)
+    type                           = optional(string, "auto-key")
+    ak_ike_gateway                 = optional(string)
+    ak_ipsec_crypto_profile        = optional(string)
+    mk_local_spi                   = optional(string)
+    mk_remote_spi                  = optional(string)
+    mk_local_address_ip            = optional(string)
+    mk_local_address_floating_ip   = optional(string)
+    mk_protocol                    = optional(string)
+    mk_auth_type                   = optional(string)
+    mk_auth_key                    = optional(string)
+    mk_esp_encryption_type         = optional(string)
+    mk_esp_encryption_key          = optional(string)
+    gps_interface                  = optional(string)
+    gps_portal_address             = optional(string)
+    gps_prefer_ipv6                = optional(bool)
+    gps_interface_ip_ipv4          = optional(string)
+    gps_interface_ip_ipv6          = optional(string)
+    gps_interface_floating_ip_ipv4 = optional(string)
+    gps_interface_floating_ip_ipv6 = optional(string)
+    gps_publish_connected_routes   = optional(bool)
+    gps_publish_routes             = optional(list(string))
+    gps_local_certificate          = optional(string)
+    gps_certificate_profile        = optional(string)
+    enable_tunnel_monitor          = optional(bool)
+    tunnel_monitor_destination_ip  = optional(string)
+    tunnel_monitor_source_ip       = optional(string)
+    tunnel_monitor_profile         = optional(string)
+    tunnel_monitor_proxy_id        = optional(string)
+  }))
+  validation {
+    condition     = alltrue([for ipsec_tunnel in var.ipsec_tunnels : contains(["auto-key", "manual-key", "global-protect-satellite"], ipsec_tunnel.type)])
+    error_message = "Valid values for type are `auto-key` (the default), `manual-key`, or `global-protect-satellite`"
+  }
+  validation {
+    condition     = alltrue([for ipsec_tunnel in var.ipsec_tunnels : contains(["md5", "sha1", "sha256", "sha384", "sha512", "none"], coalesce(ipsec_tunnel.mk_auth_type, "md5"))])
+    error_message = "Valid values for auth type are `md5`, `sha1`, `sha256`, `sha384`, `sha512`, or `none`"
+  }
+  validation {
+    condition     = alltrue([for ipsec_tunnel in var.ipsec_tunnels : contains(["esp", "ah"], coalesce(ipsec_tunnel.mk_protocol, "esp"))])
+    error_message = "Valid values for the protocol are `esp` and `ah`"
+  }
+  validation {
+    condition     = alltrue([for ipsec_tunnel in var.ipsec_tunnels : contains(["des", "3des", "aes-128-cbc", "aes-192-cbc", "aes-256-cbc"], coalesce(ipsec_tunnel.mk_esp_encryption_type, "des"))])
+    error_message = "Valid values for the encryptions are `des`, `3des`, `aes-ipsec_tunnel-cbc`, `aes-192-cbc`, `aes-256-cbc`"
+  }
+}
+variable "ipsec_tunnel_proxies" {
+  description = <<-EOF
+  Map of the IPSec tunnel proxy, where key is the IPSec tunnel proxy's name:
+  - `ipsec_tunnel` - (Required) The auto key IPSec tunnel to attach this proxy ID to.
+  - `local` - (Optional) IP subnet or IP address represents local network.
+  - `remote` - (Optional) IP subnet or IP address represents remote network.
+  - `protocol_any` - (Optional, bool) Set to true for any IP protocol.
+  - `protocol_number` - (Optional, int) IP protocol number.
+  - `protocol_tcp_local` - (Optional, int) Local TCP port number.
+  - `protocol_tcp_remote` - (Optional, int) Remote TCP port number.
+  - `protocol_udp_local` - (Optional, int) Local UDP port number.
+  - `protocol_udp_remote` - (Optional, int) Remote UDP port number.
+
+  Example:
+  ```
+  {
+    ipsec_tunnel = "some_tunnel"
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    ipsec_tunnel        = string
+    local               = optional(string)
+    remote              = optional(string)
+    protocol_any        = optional(bool, true)
+    protocol_number     = optional(number)
+    protocol_tcp_local  = optional(number)
+    protocol_tcp_remote = optional(number)
+    protocol_udp_local  = optional(number)
+    protocol_udp_remote = optional(number)
+  }))
+}

--- a/modules/ipsec/versions.tf
+++ b/modules/ipsec/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/log_forwarding_profiles/README.md
+++ b/modules/log_forwarding_profiles/README.md
@@ -1,0 +1,109 @@
+Palo Alto Networks PAN-OS Log Forwarding Profile Module
+---
+This Terraform module allows users to configure log forwarding profiles.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "log_forwarding_profiles" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/log_forwarding_profiles"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group = "test"
+
+  profiles = {
+    panorama-shared = {
+      match_lists = [
+        {
+          name             = "threat"
+          log_type         = "threat"
+          send_to_panorama = true
+        },
+        {
+          name             = "wf"
+          log_type         = "wildfire"
+          send_to_panorama = true
+        },
+        {
+          name             = "url"
+          log_type         = "url"
+          send_to_panorama = true
+        },
+        {
+          name             = "auth"
+          log_type         = "auth"
+          send_to_panorama = true
+        },
+      ]
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_log_forwarding_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/log_forwarding_profile) | resource |
+| [panos_panorama_log_forwarding_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_log_forwarding_profile) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the module. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Defines the Device Group for the deployment, used if `var.mode` is `panorama`. | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Defines the vsys for the deployment, used if `var.mode` is `ngfw`. | `string` | `"vsys1"` | no |
+| <a name="input_profiles"></a> [profiles](#input\_profiles) | Map with log forwarding profile definitions, keys are the object names:<br>- `description`: (optional) The description of the profile.<br>- `enhanced_logging`: (optional) Enable enhanced logging.<br>- `match_lists`: (optional) Match lists definitions:<br>  - `name`: (required) Name.<br>  - `description`: (required) Description.<br>  - `log_type`: (optional) Log type.<br>  - `filter`: (optional) Log filter.<br>  - `send_to_panorama`: (optional) Enable sending to Panorama.<br>  - `snmptrap_server_profiles`: (optional) List of server SNMP profiles.<br>  - `email_server_profiles`: (optional) List of server email profiles.<br>  - `syslog_server_profiles`: (optional) List of server syslog profiles.<br>  - `http_server_profiles`: (optional) List of server HTTP profiles.<br>  - `actions`: (optional) Match list actions specifications:<br>    - `name`: (required) Action name.<br>    - `azure_integration`: (optional) Enable Azure integration (mutually exclusive with `tagging_integration`).<br>    - `tagging_integration`: (optional) Tagging integration specification (mutually exclusive with `azure_integration`):<br>      - `action`: (optional) Action. Valid values are `add-tag` (default) or `remove-tag`.<br>      - `target`: (optional) Target. Valid values are `source-address` (default) or `destination-address`.<br>      - `timeout`: (optional) Amount of time (in minutes) to maintain IP address-to-tag mapping. If unset or 0 the mapping does not timeout.<br>      - `local_registration`: (optional) Local User-ID registration spec (mutually eaxclusive with `panorama_registration` and `remote_registration`):<br>        - `tags`: (required) List of administrative tags.<br>      - `panorama_registration`: (optional) Panorama User-ID registration spec (mutually eaxclusive with `local_registration` and `remote_registration`):<br>        - `tags`: (required) List of administrative tags.<br>      - `remote_registration`: (optional) Remote User-ID registration spec (mutually eaxclusive with `local_registration` and `panorama_registration`):<br>        - `tags`: (required) List of administrative tags.<br>        - `http_profile`: (required) HTTP profile.<br><br>Example:<pre>profiles = {<br>  panorama = {<br>  match_lists = [<br>    {<br>      name = "threat"<br>      log_type = "threat"<br>      send_to_panorama = true<br>    },<br>    {<br>      name = "wf"<br>      log_type = "wildfire"<br>      send_to_panorama = true<br>    },<br>    {<br>      name = "url"<br>      log_type = "url"<br>      send_to_panorama = true<br>    },<br>    {<br>      name = "auth"<br>      log_type = "auth"<br>      send_to_panorama = true<br>    },<br>  ]<br>}<br>}</pre> | <pre>map(object({<br>    description      = optional(string)<br>    enhanced_logging = optional(bool)<br>    match_lists = optional(list(object({<br>      name                     = string<br>      description              = optional(string)<br>      log_type                 = optional(string, "traffic")<br>      filter                   = optional(string, "All logs")<br>      send_to_panorama         = optional(bool)<br>      snmptrap_server_profiles = optional(list(string))<br>      email_server_profiles    = optional(list(string))<br>      syslog_server_profiles   = optional(list(string))<br>      http_server_profiles     = optional(list(string))<br>      actions = optional(list(object({<br>        name              = string<br>        azure_integration = optional(bool)<br>        tagging_integration = optional(object({<br>          action  = optional(string, "add-tag")<br>          target  = optional(string, "source-address")<br>          timeout = optional(number)<br>          local_registration = optional(object({<br>            tags = list(string)<br>          }))<br>          panorama_registration = optional(object({<br>            tags = list(string)<br>          }))<br>          remote_registration = optional(object({<br>            http_profile = string<br>            tags         = list(string)<br>          }))<br>        }))<br>      })), [])<br>    })), [])<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panos_log_forwarding_profiles"></a> [panos\_log\_forwarding\_profiles](#output\_panos\_log\_forwarding\_profiles) | n/a |
+| <a name="output_panos_panorama_log_forwarding_profiles"></a> [panos\_panorama\_log\_forwarding\_profiles](#output\_panos\_panorama\_log\_forwarding\_profiles) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/log_forwarding_profiles/main.tf
+++ b/modules/log_forwarding_profiles/main.tf
@@ -1,0 +1,169 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_log_forwarding_profile" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.profiles : {}
+
+  name = each.key
+  vsys = var.vsys
+
+  description      = each.value.description
+  enhanced_logging = each.value.enhanced_logging
+
+  dynamic "match_list" {
+    for_each = each.value.match_lists
+
+    content {
+      name                     = match_list.value.name
+      description              = match_list.value.description
+      log_type                 = match_list.value.log_type
+      filter                   = match_list.value.filter
+      send_to_panorama         = match_list.value.send_to_panorama
+      snmptrap_server_profiles = match_list.value.snmptrap_server_profiles
+      email_server_profiles    = match_list.value.email_server_profiles
+      syslog_server_profiles   = match_list.value.syslog_server_profiles
+      http_server_profiles     = match_list.value.http_server_profiles
+
+      dynamic "action" {
+        for_each = match_list.value.actions
+
+        content {
+          name = action.value.name
+
+          dynamic "azure_integration" {
+            for_each = try(action.value.azure_integration, null) != null ? [1] : []
+
+            content {
+              azure_integration = true
+            }
+          }
+
+          dynamic "tagging_integration" {
+            for_each = try(action.value.tagging_integration, null) != null ? [1] : []
+
+            content {
+              action  = action.value.tagging_integration.action
+              target  = action.value.tagging_integration.target
+              timeout = action.value.tagging_integration.timeout
+
+              dynamic "local_registration" {
+                for_each = try(action.value.tagging_integration.local_registration, null) != null ? [1] : []
+
+                content {
+                  tags = action.value.tagging_integration.local_registration.tags
+                }
+              }
+
+              dynamic "panorama_registration" {
+                for_each = try(action.value.tagging_integration.panorama_registration, null) != null ? [1] : []
+
+                content {
+                  tags = action.value.tagging_integration.panorama_registration.tags
+                }
+              }
+
+              dynamic "remote_registration" {
+                for_each = try(action.value.tagging_integration.remote_registration, null) != null ? [1] : []
+
+                content {
+                  http_profile = action.value.tagging_integration.remote_registration.http_profile
+                  tags         = action.value.tagging_integration.remote_registration.tags
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_log_forwarding_profile" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.profiles : {}
+
+  name         = each.key
+  device_group = var.device_group
+
+  description      = each.value.description
+  enhanced_logging = each.value.enhanced_logging
+
+  dynamic "match_list" {
+    for_each = each.value.match_lists
+
+    content {
+      name                     = match_list.value.name
+      description              = match_list.value.description
+      log_type                 = match_list.value.log_type
+      filter                   = match_list.value.filter
+      send_to_panorama         = match_list.value.send_to_panorama
+      snmptrap_server_profiles = match_list.value.snmptrap_server_profiles
+      email_server_profiles    = match_list.value.email_server_profiles
+      syslog_server_profiles   = match_list.value.syslog_server_profiles
+      http_server_profiles     = match_list.value.http_server_profiles
+
+      dynamic "action" {
+        for_each = match_list.value.actions
+
+        content {
+          name = action.value.name
+
+          dynamic "azure_integration" {
+            for_each = try(action.value.azure_integration, null) != null ? [1] : []
+
+            content {
+              azure_integration = true
+            }
+          }
+
+          dynamic "tagging_integration" {
+            for_each = try(action.value.tagging_integration, null) != null ? [1] : []
+
+            content {
+              action  = action.value.tagging_integration.action
+              target  = action.value.tagging_integration.target
+              timeout = action.value.tagging_integration.timeout
+
+              dynamic "local_registration" {
+                for_each = try(action.value.tagging_integration.local_registration, null) != null ? [1] : []
+
+                content {
+                  tags = action.value.tagging_integration.local_registration.tags
+                }
+              }
+
+              dynamic "panorama_registration" {
+                for_each = try(action.value.tagging_integration.panorama_registration, null) != null ? [1] : []
+
+                content {
+                  tags = action.value.tagging_integration.panorama_registration.tags
+                }
+              }
+
+              dynamic "remote_registration" {
+                for_each = try(action.value.tagging_integration.remote_registration, null) != null ? [1] : []
+
+                content {
+                  http_profile = action.value.tagging_integration.remote_registration.http_profile
+                  tags         = action.value.tagging_integration.remote_registration.tags
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/log_forwarding_profiles/main_test.go
+++ b/modules/log_forwarding_profiles/main_test.go
@@ -1,0 +1,11 @@
+package log_forwarding_profiles
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/log_forwarding_profiles/outputs.tf
+++ b/modules/log_forwarding_profiles/outputs.tf
@@ -1,0 +1,7 @@
+output "panos_log_forwarding_profiles" {
+  value = panos_log_forwarding_profile.this
+}
+
+output "panos_panorama_log_forwarding_profiles" {
+  value = panos_panorama_log_forwarding_profile.this
+}

--- a/modules/log_forwarding_profiles/variables.tf
+++ b/modules/log_forwarding_profiles/variables.tf
@@ -1,0 +1,184 @@
+variable "mode" {
+  description = "The mode to use for the module. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_group" {
+  description = "Defines the Device Group for the deployment, used if `var.mode` is `panorama`."
+  default     = "shared"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Defines the vsys for the deployment, used if `var.mode` is `ngfw`."
+  default     = "vsys1"
+  type        = string
+}
+
+variable "profiles" {
+  description = <<-EOF
+  Map with log forwarding profile definitions, keys are the object names:
+  - `description`: (optional) The description of the profile.
+  - `enhanced_logging`: (optional) Enable enhanced logging.
+  - `match_lists`: (optional) Match lists definitions:
+    - `name`: (required) Name.
+    - `description`: (required) Description.
+    - `log_type`: (optional) Log type.
+    - `filter`: (optional) Log filter.
+    - `send_to_panorama`: (optional) Enable sending to Panorama.
+    - `snmptrap_server_profiles`: (optional) List of server SNMP profiles.
+    - `email_server_profiles`: (optional) List of server email profiles.
+    - `syslog_server_profiles`: (optional) List of server syslog profiles.
+    - `http_server_profiles`: (optional) List of server HTTP profiles.
+    - `actions`: (optional) Match list actions specifications:
+      - `name`: (required) Action name.
+      - `azure_integration`: (optional) Enable Azure integration (mutually exclusive with `tagging_integration`).
+      - `tagging_integration`: (optional) Tagging integration specification (mutually exclusive with `azure_integration`):
+        - `action`: (optional) Action. Valid values are `add-tag` (default) or `remove-tag`.
+        - `target`: (optional) Target. Valid values are `source-address` (default) or `destination-address`.
+        - `timeout`: (optional) Amount of time (in minutes) to maintain IP address-to-tag mapping. If unset or 0 the mapping does not timeout.
+        - `local_registration`: (optional) Local User-ID registration spec (mutually eaxclusive with `panorama_registration` and `remote_registration`):
+          - `tags`: (required) List of administrative tags.
+        - `panorama_registration`: (optional) Panorama User-ID registration spec (mutually eaxclusive with `local_registration` and `remote_registration`):
+          - `tags`: (required) List of administrative tags.
+        - `remote_registration`: (optional) Remote User-ID registration spec (mutually eaxclusive with `local_registration` and `panorama_registration`):
+          - `tags`: (required) List of administrative tags.
+          - `http_profile`: (required) HTTP profile.
+
+  Example:
+  ```
+  profiles = {
+    panorama = {
+    match_lists = [
+      {
+        name = "threat"
+        log_type = "threat"
+        send_to_panorama = true
+      },
+      {
+        name = "wf"
+        log_type = "wildfire"
+        send_to_panorama = true
+      },
+      {
+        name = "url"
+        log_type = "url"
+        send_to_panorama = true
+      },
+      {
+        name = "auth"
+        log_type = "auth"
+        send_to_panorama = true
+      },
+    ]
+  }
+  }
+  ```
+  EOF
+
+  default = {}
+  type = map(object({
+    description      = optional(string)
+    enhanced_logging = optional(bool)
+    match_lists = optional(list(object({
+      name                     = string
+      description              = optional(string)
+      log_type                 = optional(string, "traffic")
+      filter                   = optional(string, "All logs")
+      send_to_panorama         = optional(bool)
+      snmptrap_server_profiles = optional(list(string))
+      email_server_profiles    = optional(list(string))
+      syslog_server_profiles   = optional(list(string))
+      http_server_profiles     = optional(list(string))
+      actions = optional(list(object({
+        name              = string
+        azure_integration = optional(bool)
+        tagging_integration = optional(object({
+          action  = optional(string, "add-tag")
+          target  = optional(string, "source-address")
+          timeout = optional(number)
+          local_registration = optional(object({
+            tags = list(string)
+          }))
+          panorama_registration = optional(object({
+            tags = list(string)
+          }))
+          remote_registration = optional(object({
+            http_profile = string
+            tags         = list(string)
+          }))
+        }))
+      })), [])
+    })), [])
+  }))
+
+  validation {
+    condition = alltrue([
+      for p in var.profiles : alltrue([
+        for ml in p.match_lists : contains(["traffic", "threat", "wildfire", "url", "data", "gtp", "tunnel", "auth", "sctp", "decryption"], ml.log_type)
+      ])
+    ])
+    error_message = "Valid values of 'log_type' are: 'traffic' (default), 'threat', 'wildfire', 'url', 'data', 'gtp', 'tunnel', 'auth', 'sctp', 'decryption'."
+  }
+  validation {
+    condition = alltrue([
+      for p in var.profiles : alltrue([
+        for ml in p.match_lists : alltrue([
+          for a in ml.actions : try(a.azure_integration, null) != null ? a.azure_integration == true : true
+        ])
+      ])
+    ])
+    error_message = "If 'azure_integration' is present, it has to be set to 'true'."
+  }
+  validation {
+    condition = alltrue([
+      for p in var.profiles : alltrue([
+        for ml in p.match_lists : alltrue([
+          for a in ml.actions : length(concat(
+            try(a.azure_integration, null) != null ? ["a"] : [],
+            try(a.tagging_integration, null) != null ? ["t"] : []
+          )) <= 1 ? true : false
+        ])
+      ])
+    ])
+    error_message = "'azure_integration' and 'tagging_integration' are mutually exclusive."
+  }
+  validation {
+    condition = alltrue([
+      for p in var.profiles : alltrue([
+        for ml in p.match_lists : alltrue([
+          for a in ml.actions : try(a.tagging_integration, null) != null ? contains(["add-tag", "remove-tag"], coalesce(a.tagging_integration.action, "add-tag")) : true
+        ])
+      ])
+    ])
+    error_message = "Valid values of 'action' for 'tagging_integration' are 'add-tag', 'remove-tag'."
+  }
+  validation {
+    condition = alltrue([
+      for p in var.profiles : alltrue([
+        for ml in p.match_lists : alltrue([
+          for a in ml.actions : try(a.tagging_integration, null) != null ? contains(["source-address", "destination-address"], coalesce(a.tagging_integration.target, "source-address")) : true
+        ])
+      ])
+    ])
+    error_message = "Valid values of 'target' for 'tagging_integration' are 'source-address', 'destination-address'."
+  }
+  validation {
+    condition = alltrue([
+      for p in var.profiles : alltrue([
+        for ml in p.match_lists : alltrue([
+          for a in ml.actions : length(concat(
+            try(a.tagging_integration.local_registration, null) != null ? ["l"] : [],
+            try(a.tagging_integration.panorama_registration, null) != null ? ["p"] : [],
+            try(a.tagging_integration.remote_registration, null) != null ? ["r"] : []
+          )) <= 1 ? true : false
+        ])
+      ])
+    ])
+    error_message = "'local_registration', 'panorama_registration', 'remote_registration' are mutually exclusive."
+  }
+}

--- a/modules/log_forwarding_profiles/versions.tf
+++ b/modules/log_forwarding_profiles/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/management_profiles/README.md
+++ b/modules/management_profiles/README.md
@@ -1,0 +1,94 @@
+Palo Alto Networks PAN-OS Management Profiles Module
+---
+This Terraform module allows users to configure management profiles.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "management_profiles" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/management_profiles"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  template = "test"
+
+  management_profiles = {
+    "mgmt_default" = {
+        ping          = true
+        telnet        = false
+        ssh           = true
+        http          = false
+        https         = true
+        snmp          = false
+        permitted_ips = ["1.1.1.1/32", "2.2.2.2/32"]
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_management_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/management_profile) | resource |
+| [panos_panorama_management_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_management_profile) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_template"></a> [template](#input\_template) | The template name. | `string` | `"default"` | no |
+| <a name="input_template_stack"></a> [template\_stack](#input\_template\_stack) | The template stack name. | `string` | `""` | no |
+| <a name="input_management_profiles"></a> [management\_profiles](#input\_management\_profiles) | Map of the management profiles, where key is the management profile's name:<br>- `ping` - (Optional) Allow ping.<br>- `telnet` - (Optional) Allow telnet.<br>- `ssh` - (Optional) Allow SSH.<br>- `http` - (Optional) Allow HTTP.<br>- `http_ocsp` - (Optional) Allow HTTP OCSP.<br>- `https` - (Optional) Allow HTTPS.<br>- `snmp` - (Optional) Allow SNMP.<br>- `response_pages` - (Optional) Allow response pages.<br>- `userid_service` - (Optional) Allow User ID service.<br>- `userid_syslog_listener_ssl` - (Optional) Allow User ID syslog listener for SSL.<br>- `userid_syslog_listener_udp` - (Optional) Allow User ID syslog listener for UDP.<br>- `permitted_ips` - (Optional) The list of permitted IP addresses or address ranges for this management profile.<br><br>Example:<pre>{<br>  "mgmt_default" = {<br>    ping           = true<br>    telnet         = false<br>    ssh            = true<br>    http           = false<br>    https          = true<br>    snmp           = false<br>    userid_service = null<br>    permitted_ips  = ["1.1.1.1/32", "2.2.2.2/32"]<br>  }<br>}</pre> | <pre>map(object({<br>    ping                       = optional(bool)<br>    telnet                     = optional(bool)<br>    ssh                        = optional(bool)<br>    http                       = optional(bool)<br>    http_ocsp                  = optional(bool)<br>    https                      = optional(bool)<br>    snmp                       = optional(bool)<br>    response_pages             = optional(bool)<br>    userid_service             = optional(bool)<br>    userid_syslog_listener_ssl = optional(bool)<br>    userid_syslog_listener_udp = optional(bool)<br>    permitted_ips              = list(string)<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panorama_management_profiles"></a> [panorama\_management\_profiles](#output\_panorama\_management\_profiles) | n/a |
+| <a name="output_management_profiles"></a> [management\_profiles](#output\_management\_profiles) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/management_profiles/main.tf
+++ b/modules/management_profiles/main.tf
@@ -1,0 +1,52 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_panorama_management_profile" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.management_profiles : {}
+
+  template       = var.template_stack == "" ? var.template : null
+  template_stack = var.template_stack == "" ? null : var.template_stack
+
+  name                       = each.key
+  ping                       = each.value.ping
+  telnet                     = each.value.telnet
+  ssh                        = each.value.ssh
+  http                       = each.value.http
+  https                      = each.value.https
+  snmp                       = each.value.snmp
+  response_pages             = each.value.response_pages
+  userid_service             = each.value.userid_service
+  userid_syslog_listener_ssl = each.value.userid_syslog_listener_ssl
+  userid_syslog_listener_udp = each.value.userid_syslog_listener_udp
+  permitted_ips              = each.value.permitted_ips
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_management_profile" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.management_profiles : {}
+
+  name                       = each.key
+  ping                       = each.value.ping
+  telnet                     = each.value.telnet
+  ssh                        = each.value.ssh
+  http                       = each.value.http
+  https                      = each.value.https
+  snmp                       = each.value.snmp
+  response_pages             = each.value.response_pages
+  userid_service             = each.value.userid_service
+  userid_syslog_listener_ssl = each.value.userid_syslog_listener_ssl
+  userid_syslog_listener_udp = each.value.userid_syslog_listener_udp
+  permitted_ips              = each.value.permitted_ips
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/management_profiles/main_test.go
+++ b/modules/management_profiles/main_test.go
@@ -1,0 +1,11 @@
+package management_profiles
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/management_profiles/outputs.tf
+++ b/modules/management_profiles/outputs.tf
@@ -1,0 +1,7 @@
+output "panorama_management_profiles" {
+  value = panos_panorama_management_profile.this
+}
+
+output "management_profiles" {
+  value = panos_management_profile.this
+}

--- a/modules/management_profiles/variables.tf
+++ b/modules/management_profiles/variables.tf
@@ -1,0 +1,69 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "template" {
+  description = "The template name."
+  default     = "default"
+  type        = string
+}
+
+variable "template_stack" {
+  description = "The template stack name."
+  default     = ""
+  type        = string
+}
+
+variable "management_profiles" {
+  description = <<-EOF
+  Map of the management profiles, where key is the management profile's name:
+  - `ping` - (Optional) Allow ping.
+  - `telnet` - (Optional) Allow telnet.
+  - `ssh` - (Optional) Allow SSH.
+  - `http` - (Optional) Allow HTTP.
+  - `http_ocsp` - (Optional) Allow HTTP OCSP.
+  - `https` - (Optional) Allow HTTPS.
+  - `snmp` - (Optional) Allow SNMP.
+  - `response_pages` - (Optional) Allow response pages.
+  - `userid_service` - (Optional) Allow User ID service.
+  - `userid_syslog_listener_ssl` - (Optional) Allow User ID syslog listener for SSL.
+  - `userid_syslog_listener_udp` - (Optional) Allow User ID syslog listener for UDP.
+  - `permitted_ips` - (Optional) The list of permitted IP addresses or address ranges for this management profile.
+
+  Example:
+  ```
+  {
+    "mgmt_default" = {
+      ping           = true
+      telnet         = false
+      ssh            = true
+      http           = false
+      https          = true
+      snmp           = false
+      userid_service = null
+      permitted_ips  = ["1.1.1.1/32", "2.2.2.2/32"]
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    ping                       = optional(bool)
+    telnet                     = optional(bool)
+    ssh                        = optional(bool)
+    http                       = optional(bool)
+    http_ocsp                  = optional(bool)
+    https                      = optional(bool)
+    snmp                       = optional(bool)
+    response_pages             = optional(bool)
+    userid_service             = optional(bool)
+    userid_syslog_listener_ssl = optional(bool)
+    userid_syslog_listener_udp = optional(bool)
+    permitted_ips              = list(string)
+  }))
+}

--- a/modules/management_profiles/versions.tf
+++ b/modules/management_profiles/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/nat_policies/README.md
+++ b/modules/nat_policies/README.md
@@ -1,0 +1,116 @@
+Palo Alto Networks PAN-OS NAT Policies Module
+---
+This Terraform module allows users to configure NAT policies.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "nat_policies" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/nat_policies"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group = "test"
+  nat_policies = {
+    "required_nat" = {
+        rulebase = "pre-rulebase"
+        rules = [
+        {
+          name = "DNS config rule"
+          tags = [
+            "dns-proxy",
+            "Managed by Terraform"
+          ]
+          original_packet = {
+            destination_addresses = ["any"]
+            destination_zone      = "Trust-L3"
+            source_addresses      = ["any"]
+            source_zones          = ["Untrust-L3"]
+            service               = "any"
+          }
+          translated_packet = {
+            source = {
+              dynamic_ip = {
+              translated_addresses = ["DNS-Servers"]
+              }
+            }
+            destination = {
+              static_translation = {
+              address = "2.2.2.2"
+              port    = "80"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_nat_rule_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/nat_rule_group) | resource |
+| [panos_panorama_nat_rule_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_nat_rule_group) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if _mode_ is panorama, this defines the Device Group for the deployment | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if _mode_ is ngfw, this defines the vsys for the deployment | `string` | `"vsys1"` | no |
+| <a name="input_nat_policies"></a> [nat\_policies](#input\_nat\_policies) | Map with NAT policy rule objects.<br>- `rulebase`: (optional) The rulebase for the NAT Policy. Valid values are `pre-rulebase` and `post-rulebase` (default: `pre-rulebase`).<br>- `position_keyword`: (optional) A positioning keyword for this group. Valid values are `before`, `directly before`, `after`, `directly after`, `top`, `bottom`, or left empty to have no particular placement (default: empty). This parameter works in combination with the `position_reference` parameter.<br>- `position_reference`: (optional) Required if `position_keyword` is one of the "above" or "below" variants, this is the name of a non-group rule to use as a reference to place this group.<br>- `rules`: (optional) The NAT rule definition. The NAT rule ordering will match how they appear in the terraform plan file.<br>  - `name`: (required) The NAT rule's name.<br>  - `description`: (optional) The description of the NAT rule.<br>  - `audit_comment`: (optional) When this rule is created/updated, the audit comment to apply for this rule.<br>  - `type`: (optional) NAT type. Valid values are `ipv4`, `nat64`, or `nptv6` (default: `ipv4`).<br>  - `tags`: (optional) List of administrative tags.<br>  - `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).<br>  - `group_tag`: (optional) The group tag.<br>  - `uuid`: (optional) The PAN-OS UUID.<br>  - `original_packet`: (required) The original packet specification.<br>    - `source_zones`: (optional) List of source zones (default: `any`).<br>    - `destination_zone`: (optional) The destination zone (default: `any`).<br>    - `destination_interface`: (optional) Egress interface from the lookup (default: `any`).<br>    - `service`: (optional) Service for the original packet (default: `any`).<br>    - `source_addresses`: (optional) List of source addresses (default: `any`).<br>    - `destination_addresses`: (optional) List of destination addresses (default: `any`).<br>  - `translated_packet`: (required) The translated packet specifications.<br>    - `source`: (optional) The source specification. Valid values are `none`, `dynamic_ip_port`, `dynamic_ip`, or `static_ip` (default: `none`).<br>      - `dynamic_ip_and_port`: (optional) Dynamic IP and port source translation specification.<br>        - `translated_addresses`: (optional) Not functional if `interface_address` is configured. List of translated addresses.<br>        - `interface_address`: (optional) Not functional if `translated_addresses` is configured. Interface address source translation type specifications.<br>          - `interface`: (required) The interface.<br>          - `ip_address`: (optional) The IP address.<br>      - `dynamic_ip`: (optional) Dynamic IP source translation specification.<br>        - `translated_addresses`: (optional) The list of translated addresses.<br>        - `fallback`: (optional) The fallback specifications.<br>          - `translated_addresses`: (optional) Not functional if `interface_address` is configured. List of translated addresses.<br>          - `interface_address`: (optional) Not functional if `translated address` is configured. The interface address fallback specifications.<br>            - `interface`: (required) Source address translated fallback interface.<br>            - `type`: (optional) Type of interface fallback. Valid values are `ip` or `floating` (default: `ip`).<br>            - `ip_address`: (optional) IP address of the fallback interface.<br>      - `static_ip`: (optional) Static IP source translation specifications.<br>        - `translated_address`: (required) The statically translated source address.<br>        - `bi_directional`: (optional) Boolean enabling bi-directional source address translation (default: `false`).<br>    - `destination`: (optional) The destination specification. Valid values are `none`, `static_translation`, or `dynamic_translation` (default: `none`).<br>      - `static_translation`: (optional) Specifies a static destination NAT.<br>        - `address`: (required) Destination address translation address.<br>        - `port`: (optional) Integer destination address translation port number.<br>      - `dynamic_translation`: (optional) Specify a dynamic destination NAT. Only available for PAN-OS 8.1+.<br>        - `address`: (required) Destination address translation address.<br>        - `port`: (optional) Integer destination address translation port number.<br>        - `distribution`: (optional) Distribution algorithm for destination address pool. Valid values are `round-robin`, `source-ip-hash`, `ip-modulo`, `ip-hash`, or `least-sessions` (default: `round-robin`). Only available for PAN-OS 8.1+.<br><br>Example:<pre>"required_nat" = {<br>  rulebase = "pre-rulebase"<br>  rules    = [<br>    {<br>      name = "DNS config rule"<br>      tags = [<br>        "dns-proxy",<br>        "Managed by Terraform"<br>      ]<br>      original_packet = {<br>        destination_addresses = ["any"]<br>        destination_zone      = "Trust-L3"<br>        source_addresses      = ["any"]<br>        source_zones          = ["Untrust-L3"]<br>        service               = "any"<br>      }<br>      translated_packet = {<br>        source = {<br>          dynamic_ip = {<br>            translated_addresses = ["DNS-Servers"]<br>            fallback = {<br>              interface_address = {<br>                interface = "ethernet1/1"<br>              }<br>            }<br>          }<br>        }<br>        destination = {<br>          static_translation = {<br>            address = "2.2.2.2"<br>            port    = "80"<br>          }<br>        }<br>      }<br>    }<br>  ]<br>}</pre> | <pre>map(object({<br>    rulebase           = optional(string, "pre-rulebase")<br>    position_keyword   = optional(string, "")<br>    position_reference = optional(string)<br>    rules = list(object({<br>      name          = string<br>      audit_comment = optional(string)<br>      description   = optional(string)<br>      tags          = optional(list(string))<br>      type          = optional(string, "ipv4")<br>      disabled      = optional(bool, false)<br>      group_tag     = optional(string)<br>      uuid          = optional(string)<br>      original_packet = object({<br>        destination_addresses = optional(list(string), ["any"])<br>        destination_zone      = string<br>        destination_interface = optional(string, "any")<br>        source_addresses      = optional(list(string), ["any"])<br>        source_zones          = list(string)<br>        service               = optional(string, "any")<br>      })<br>      translated_packet = optional(object({<br>        destination = optional(object({<br>          static_translation = optional(object({<br>            address = string<br>            port    = optional(string)<br>          }))<br>          dynamic_translation = optional(object({<br>            address      = optional(string)<br>            port         = optional(string)<br>            distribution = optional(string)<br>          }))<br>        }))<br>        source = optional(object({<br>          dynamic_ip_and_port = optional(object({<br>            translated_address = optional(object({<br>              translated_addresses = optional(list(string))<br>            }))<br>            interface_address = optional(object({<br>              interface  = string<br>              ip_address = optional(string)<br>            }))<br>          }))<br>          dynamic_ip = optional(object({<br>            translated_addresses = list(string)<br>            fallback = optional(object({<br>              translated_address = optional(object({<br>                translated_addresses = list(string)<br>              }))<br>              interface_address = optional(object({<br>                interface  = string<br>                type       = optional(string)<br>                ip_address = optional(string, "ip")<br>              }))<br>            }))<br>          }))<br>          static_ip = optional(object({<br>            translated_address = string<br>            bi_directional     = optional(bool)<br>          }))<br>        }))<br>      }))<br>      negate_target = optional(bool, false)<br>      target = optional(list(object({<br>        serial    = string<br>        vsys_list = optional(list(string))<br>      })), null)<br>    }))<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panos_panorama_nat_rule_group"></a> [panos\_panorama\_nat\_rule\_group](#output\_panos\_panorama\_nat\_rule\_group) | n/a |
+| <a name="output_panos_nat_rule_group"></a> [panos\_nat\_rule\_group](#output\_panos\_nat\_rule\_group) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nat_policies/main.tf
+++ b/modules/nat_policies/main.tf
@@ -1,0 +1,252 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_panorama_nat_rule_group" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.nat_policies : {}
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  rulebase     = local.mode_map[var.mode] == 0 ? each.value.rulebase : null
+
+  position_keyword   = each.value.position_keyword
+  position_reference = each.value.position_reference
+
+
+  dynamic "rule" {
+    for_each = each.value.rules
+
+    content {
+      name          = rule.value.name
+      audit_comment = rule.value.audit_comment
+      description   = rule.value.description
+      tags          = rule.value.tags
+      type          = rule.value.type
+      disabled      = rule.value.disabled
+      group_tag     = rule.value.group_tag
+      uuid          = rule.value.uuid
+
+      original_packet {
+        destination_addresses = rule.value.original_packet.destination_addresses
+        destination_zone      = rule.value.original_packet.destination_zone
+        source_addresses      = rule.value.original_packet.source_addresses
+        source_zones          = rule.value.original_packet.source_zones
+        service               = rule.value.original_packet.service
+      }
+
+      translated_packet {
+
+        destination {
+          dynamic "static_translation" {
+            for_each = try(rule.value.translated_packet.destination.static_translation, null) != null ? [1] : []
+            content {
+              address = rule.value.translated_packet.destination.static_translation.address
+              port    = rule.value.translated_packet.destination.static_translation.port
+            }
+          }
+          dynamic "dynamic_translation" {
+            for_each = try(rule.value.translated_packet.destination.dynamic_translation, null) != null ? [1] : []
+            content {
+              address      = rule.value.translated_packet.destination.dynamic_translation.address
+              port         = rule.value.translated_packet.destination.dynamic_translation.port
+              distribution = rule.value.translated_packet.destination.dynamic_translation.distribution
+            }
+          }
+        }
+
+        source {
+          dynamic "dynamic_ip_and_port" {
+            for_each = try(rule.value.translated_packet.source.dynamic_ip_and_port, null) != null ? [1] : []
+            content {
+              dynamic "translated_address" {
+                for_each = try(rule.value.translated_packet.source.dynamic_ip_and_port.translated_address, null) != null ? [1] : []
+                content {
+                  translated_addresses = rule.value.translated_packet.source.dynamic_ip_and_port.translated_address.translated_addresses
+                }
+              }
+              dynamic "interface_address" {
+                for_each = try(rule.value.translated_packet.source.dynamic_ip_and_port.interface_address, null) != null ? [1] : []
+                content {
+                  interface  = rule.value.translated_packet.source.dynamic_ip_and_port.interface_address.interface
+                  ip_address = rule.value.translated_packet.source.dynamic_ip_and_port.interface_address.ip_address
+                }
+              }
+            }
+          }
+
+          dynamic "dynamic_ip" {
+            for_each = try(rule.value.translated_packet.source.dynamic_ip, null) != null ? [1] : []
+            content {
+              translated_addresses = rule.value.translated_packet.source.dynamic_ip.translated_addresses
+              dynamic "fallback" {
+                for_each = try(rule.value.translated_packet.source.dynamic_ip.fallback, null) != null ? [1] : []
+                content {
+                  dynamic "translated_address" {
+                    for_each = try(rule.value.translated_packet.source.dynamic_ip.fallback.translated_address, null) != null ? [1] : []
+                    content {
+                      translated_addresses = rule.value.translated_packet.source.dynamic_ip.fallback.translated_address.translated_addresses
+                    }
+                  }
+                  dynamic "interface_address" {
+                    for_each = try(rule.value.translated_packet.source.dynamic_ip.fallback.interface_address, null) != null ? [1] : []
+                    content {
+                      interface  = rule.value.translated_packet.source.dynamic_ip.fallback.interface_address.interface
+                      type       = rule.value.translated_packet.source.dynamic_ip.fallback.interface_address.type
+                      ip_address = rule.value.translated_packet.source.dynamic_ip.fallback.interface_address.ip_address
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          dynamic "static_ip" {
+            for_each = try(rule.value.translated_packet.source.static_ip, null) != null ? [1] : []
+            content {
+              translated_address = rule.value.translated_packet.source.static_ip.translated_address
+              bi_directional     = rule.value.translated_packet.source.static_ip.bi_directional
+            }
+          }
+        }
+      }
+
+      dynamic "target" {
+        for_each = try(rule.value.target, null) != null ? { for t in rule.value.target : t.serial => t } : {}
+        content {
+          serial    = target.value.serial
+          vsys_list = target.value.vsys_list
+        }
+      }
+
+      negate_target = rule.value.negate_target
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+resource "panos_nat_rule_group" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.nat_policies : {}
+
+  vsys = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  position_keyword   = each.value.position_keyword
+  position_reference = each.value.position_reference
+
+
+  dynamic "rule" {
+    for_each = each.value.rules
+
+    content {
+      name        = rule.value.name
+      description = rule.value.description
+      tags        = rule.value.tags
+      type        = rule.value.type
+      disabled    = rule.value.disabled
+
+      dynamic "target" {
+        for_each = try(rule.value.target, null) != null ? { for t in rule.value.target : t.serial => t } : {}
+        content {
+          serial    = target.value.serial
+          vsys_list = target.value.vsys_list
+        }
+      }
+
+      negate_target = rule.value.negate_target
+
+      original_packet {
+        destination_addresses = rule.value.original_packet.destination_addresses
+        destination_zone      = rule.value.original_packet.destination_zone
+        source_addresses      = rule.value.original_packet.source_addresses
+        source_zones          = rule.value.original_packet.source_zones
+        service               = rule.value.original_packet.service
+      }
+
+      translated_packet {
+
+        destination {
+          dynamic "static_translation" {
+            for_each = try(rule.value.translated_packet.destination.static_translation, null) != null ? [1] : []
+            content {
+              address = rule.value.translated_packet.destination.static_translation.address
+              port    = rule.value.translated_packet.destination.static_translation.port
+            }
+          }
+          dynamic "dynamic_translation" {
+            for_each = try(rule.value.translated_packet.destination.dynamic_translation, null) != null ? [1] : []
+            content {
+              address      = rule.value.translated_packet.destination.dynamic_translation.address
+              port         = rule.value.translated_packet.destination.dynamic_translation.port
+              distribution = rule.value.translated_packet.destination.dynamic_translation.distribution
+            }
+          }
+        }
+
+        source {
+          dynamic "dynamic_ip_and_port" {
+            for_each = try(rule.value.translated_packet.source.dynamic_ip_and_port, null) != null ? [1] : []
+            content {
+              dynamic "translated_address" {
+                for_each = try(rule.value.translated_packet.source.dynamic_ip_and_port.translated_address, null) != null ? [1] : []
+                content {
+                  translated_addresses = rule.value.translated_packet.source.dynamic_ip_and_port.translated_address.translated_addresses
+                }
+              }
+              dynamic "interface_address" {
+                for_each = try(rule.value.translated_packet.source.dynamic_ip_and_port.interface_address, null) != null ? [1] : []
+                content {
+                  interface  = rule.value.translated_packet.source.dynamic_ip_and_port.interface_address.interface
+                  ip_address = rule.value.translated_packet.source.dynamic_ip_and_port.interface_address.ip_address
+                }
+              }
+            }
+          }
+
+          dynamic "dynamic_ip" {
+            for_each = try(rule.value.translated_packet.source.dynamic_ip, null) != null ? [1] : []
+            content {
+              translated_addresses = rule.value.translated_packet.source.dynamic_ip.translated_addresses
+              dynamic "fallback" {
+                for_each = try(rule.value.translated_packet.source.dynamic_ip.fallback, null) != null ? [1] : []
+                content {
+                  dynamic "translated_address" {
+                    for_each = try(rule.value.translated_packet.source.dynamic_ip.fallback.translated_address, null) != null ? [1] : []
+                    content {
+                      translated_addresses = rule.value.translated_packet.source.dynamic_ip.fallback.translated_address.translated_addresses
+                    }
+                  }
+                  dynamic "interface_address" {
+                    for_each = try(rule.value.translated_packet.source.dynamic_ip.fallback.interface_address, null) != null ? [1] : []
+                    content {
+                      interface  = rule.value.translated_packet.source.dynamic_ip.fallback.interface_address.interface
+                      type       = rule.value.translated_packet.source.dynamic_ip.fallback.interface_address.type
+                      ip_address = rule.value.translated_packet.source.dynamic_ip.fallback.interface_address.ip_address
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          dynamic "static_ip" {
+            for_each = try(rule.value.translated_packet.source.static_ip, null) != null ? [1] : []
+            content {
+              translated_address = try(rule.value.translated_packet.source.static_ip.translated_address, null)
+              bi_directional     = try(rule.value.translated_packet.source.static_ip.bi_directional, false)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/nat_policies/main_test.go
+++ b/modules/nat_policies/main_test.go
@@ -1,0 +1,11 @@
+package nat_policies
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/nat_policies/outputs.tf
+++ b/modules/nat_policies/outputs.tf
@@ -1,0 +1,8 @@
+output "panos_panorama_nat_rule_group" {
+  value = panos_panorama_nat_rule_group.this
+}
+
+output "panos_nat_rule_group" {
+  value = panos_nat_rule_group.this
+}
+

--- a/modules/nat_policies/variables.tf
+++ b/modules/nat_policies/variables.tf
@@ -1,0 +1,199 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_group" {
+  description = "Used if _mode_ is panorama, this defines the Device Group for the deployment"
+  default     = "shared"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if _mode_ is ngfw, this defines the vsys for the deployment"
+  default     = "vsys1"
+  type        = string
+}
+
+variable "nat_policies" {
+  description = <<-EOF
+  Map with NAT policy rule objects.
+  - `rulebase`: (optional) The rulebase for the NAT Policy. Valid values are `pre-rulebase` and `post-rulebase` (default: `pre-rulebase`).
+  - `position_keyword`: (optional) A positioning keyword for this group. Valid values are `before`, `directly before`, `after`, `directly after`, `top`, `bottom`, or left empty to have no particular placement (default: empty). This parameter works in combination with the `position_reference` parameter.
+  - `position_reference`: (optional) Required if `position_keyword` is one of the "above" or "below" variants, this is the name of a non-group rule to use as a reference to place this group.
+  - `rules`: (optional) The NAT rule definition. The NAT rule ordering will match how they appear in the terraform plan file.
+    - `name`: (required) The NAT rule's name.
+    - `description`: (optional) The description of the NAT rule.
+    - `audit_comment`: (optional) When this rule is created/updated, the audit comment to apply for this rule.
+    - `type`: (optional) NAT type. Valid values are `ipv4`, `nat64`, or `nptv6` (default: `ipv4`).
+    - `tags`: (optional) List of administrative tags.
+    - `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).
+    - `group_tag`: (optional) The group tag.
+    - `uuid`: (optional) The PAN-OS UUID.
+    - `original_packet`: (required) The original packet specification.
+      - `source_zones`: (optional) List of source zones (default: `any`).
+      - `destination_zone`: (optional) The destination zone (default: `any`).
+      - `destination_interface`: (optional) Egress interface from the lookup (default: `any`).
+      - `service`: (optional) Service for the original packet (default: `any`).
+      - `source_addresses`: (optional) List of source addresses (default: `any`).
+      - `destination_addresses`: (optional) List of destination addresses (default: `any`).
+    - `translated_packet`: (required) The translated packet specifications.
+      - `source`: (optional) The source specification. Valid values are `none`, `dynamic_ip_port`, `dynamic_ip`, or `static_ip` (default: `none`).
+        - `dynamic_ip_and_port`: (optional) Dynamic IP and port source translation specification.
+          - `translated_addresses`: (optional) Not functional if `interface_address` is configured. List of translated addresses.
+          - `interface_address`: (optional) Not functional if `translated_addresses` is configured. Interface address source translation type specifications.
+            - `interface`: (required) The interface.
+            - `ip_address`: (optional) The IP address.
+        - `dynamic_ip`: (optional) Dynamic IP source translation specification.
+          - `translated_addresses`: (optional) The list of translated addresses.
+          - `fallback`: (optional) The fallback specifications.
+            - `translated_addresses`: (optional) Not functional if `interface_address` is configured. List of translated addresses.
+            - `interface_address`: (optional) Not functional if `translated address` is configured. The interface address fallback specifications.
+              - `interface`: (required) Source address translated fallback interface.
+              - `type`: (optional) Type of interface fallback. Valid values are `ip` or `floating` (default: `ip`).
+              - `ip_address`: (optional) IP address of the fallback interface.
+        - `static_ip`: (optional) Static IP source translation specifications.
+          - `translated_address`: (required) The statically translated source address.
+          - `bi_directional`: (optional) Boolean enabling bi-directional source address translation (default: `false`).
+      - `destination`: (optional) The destination specification. Valid values are `none`, `static_translation`, or `dynamic_translation` (default: `none`).
+        - `static_translation`: (optional) Specifies a static destination NAT.
+          - `address`: (required) Destination address translation address.
+          - `port`: (optional) Integer destination address translation port number.
+        - `dynamic_translation`: (optional) Specify a dynamic destination NAT. Only available for PAN-OS 8.1+.
+          - `address`: (required) Destination address translation address.
+          - `port`: (optional) Integer destination address translation port number.
+          - `distribution`: (optional) Distribution algorithm for destination address pool. Valid values are `round-robin`, `source-ip-hash`, `ip-modulo`, `ip-hash`, or `least-sessions` (default: `round-robin`). Only available for PAN-OS 8.1+.
+
+  Example:
+  ```
+  "required_nat" = {
+    rulebase = "pre-rulebase"
+    rules    = [
+      {
+        name = "DNS config rule"
+        tags = [
+          "dns-proxy",
+          "Managed by Terraform"
+        ]
+        original_packet = {
+          destination_addresses = ["any"]
+          destination_zone      = "Trust-L3"
+          source_addresses      = ["any"]
+          source_zones          = ["Untrust-L3"]
+          service               = "any"
+        }
+        translated_packet = {
+          source = {
+            dynamic_ip = {
+              translated_addresses = ["DNS-Servers"]
+              fallback = {
+                interface_address = {
+                  interface = "ethernet1/1"
+                }
+              }
+            }
+          }
+          destination = {
+            static_translation = {
+              address = "2.2.2.2"
+              port    = "80"
+            }
+          }
+        }
+      }
+    ]
+  }
+  ```
+
+  EOF
+  default     = {}
+
+  type = map(object({
+    rulebase           = optional(string, "pre-rulebase")
+    position_keyword   = optional(string, "")
+    position_reference = optional(string)
+    rules = list(object({
+      name          = string
+      audit_comment = optional(string)
+      description   = optional(string)
+      tags          = optional(list(string))
+      type          = optional(string, "ipv4")
+      disabled      = optional(bool, false)
+      group_tag     = optional(string)
+      uuid          = optional(string)
+      original_packet = object({
+        destination_addresses = optional(list(string), ["any"])
+        destination_zone      = string
+        destination_interface = optional(string, "any")
+        source_addresses      = optional(list(string), ["any"])
+        source_zones          = list(string)
+        service               = optional(string, "any")
+      })
+      translated_packet = optional(object({
+        destination = optional(object({
+          static_translation = optional(object({
+            address = string
+            port    = optional(string)
+          }))
+          dynamic_translation = optional(object({
+            address      = optional(string)
+            port         = optional(string)
+            distribution = optional(string)
+          }))
+        }))
+        source = optional(object({
+          dynamic_ip_and_port = optional(object({
+            translated_address = optional(object({
+              translated_addresses = optional(list(string))
+            }))
+            interface_address = optional(object({
+              interface  = string
+              ip_address = optional(string)
+            }))
+          }))
+          dynamic_ip = optional(object({
+            translated_addresses = list(string)
+            fallback = optional(object({
+              translated_address = optional(object({
+                translated_addresses = list(string)
+              }))
+              interface_address = optional(object({
+                interface  = string
+                type       = optional(string)
+                ip_address = optional(string, "ip")
+              }))
+            }))
+          }))
+          static_ip = optional(object({
+            translated_address = string
+            bi_directional     = optional(bool)
+          }))
+        }))
+      }))
+      negate_target = optional(bool, false)
+      target = optional(list(object({
+        serial    = string
+        vsys_list = optional(list(string))
+      })), null)
+    }))
+  }))
+  validation {
+    condition = alltrue([
+      for rule_group in var.nat_policies : alltrue([
+        for rule in rule_group.rules :
+        contains(["ipv4", "nat64", "natv6"], coalesce(rule.type, "ipv4"))
+      ])
+    ])
+    error_message = "Valid types of type are `ipv4`, `nat64`, `natv6`"
+  }
+  validation {
+    condition = alltrue([
+      for rule_group in var.nat_policies : contains(["", "before", "after", "directly before", "directly after", "top", "bottom"], rule_group.position_keyword)
+    ])
+    error_message = "Valid types of type are `before`, `directly before`, `after`, `directly after`, `top`, `bottom`, or left empty"
+  }
+}

--- a/modules/nat_policies/versions.tf
+++ b/modules/nat_policies/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/security_policy/README.md
+++ b/modules/security_policy/README.md
@@ -1,0 +1,171 @@
+Palo Alto Networks PAN-OS security policy module
+---
+This Terraform module allows users to configure a **complete** security policy within specified Virtual System (when target device is a firewall) or Devive Group/Rulebase pair (when target device is Panorama). Target device is determined by `mode` variable.
+
+:warning: Input configuration for the module determines full security posture within the specified scope - vsys or device group/rulebase pair. `panos_security_policy` resource used by the module enforces both the contents of individual rules as well as their ordering, any existing rule that does not exist in the input configuration will be removed.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "security_policy" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/security_policy"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group      = "test"
+  rulebase          = "pre-rulebase"
+  rules = [
+    {
+      name = "Allow access to DNS Servers"
+      tags = [
+        "Outbound",
+        "Managed by Terraform"
+      ]
+      source_zones          = ["Trust-L3"]
+      source_addresses      = ["RFC1918_Subnets"]
+      destination_zones     = ["Untrust-L3"]
+      destination_addresses = ["DNS-Servers"]
+      applications          = ["dns"]
+      services              = ["application-default"]
+      action                = "allow"
+      log_end               = "true"
+      virus                 = "default"
+      spyware               = "default"
+      vulnerability         = "default"
+    },
+    {
+      name             = "Allow access to RFC1918"
+      tags             = ["Managed by Terraform"]
+      source_zones     = ["Trust-L3"]
+      source_addresses = ["RFC1918_Subnets"]
+      destination_zones = [
+        "Trust-L3",
+        "Untrust-L3"
+      ]
+      destination_addresses = ["RFC1918_Subnets"]
+      services              = ["application-default"]
+      action                = "allow"
+      log_end               = "true"
+      virus                 = "default"
+      spyware               = "default"
+      vulnerability         = "default"
+    },
+    {
+      name = "Disabled - temporary access to Srv10 and Srv11"
+      tags = [
+        "Outbound",
+        "Managed by Terraform"
+      ]
+      source_zones = ["Trust-L3"]
+      source_addresses = [
+        "Server10",
+        "Server11"
+      ]
+      destination_zones     = ["Untrust-L3"]
+      destination_addresses = ["123.123.123.123/32"]
+      services              = ["SSH-8022"]
+      action                = "allow"
+      log_end               = "true"
+      disabled              = "true"
+      virus                 = "default"
+      spyware               = "default"
+      vulnerability         = "default"
+      url_filtering         = "default"
+      file_blocking         = "basic file blocking"
+      wildfire_analysis     = "default"
+    },
+    {
+      name = "Allow access to SSH Servers"
+      tags = [
+        "Inbound",
+        "Managed by Terraform"
+      ]
+      source_zones          = ["Untrust-L3"]
+      negate_source         = "false"
+      destination_zones     = ["Trust-L3"]
+      destination_addresses = ["SSH-Servers"]
+      negate_destination    = "false"
+      applications          = ["ssh"]
+      services              = ["application-default"]
+      action                = "allow"
+      log_end               = "true"
+    },
+    {
+      name = "Block Some Traffic"
+      tags = [
+        "Outbound",
+        "Managed by Terraform"
+      ]
+      source_zones     = ["Trust-L3"]
+      source_addresses = ["10.0.0.100/32"]
+      action           = "deny"
+      log_end          = "true"
+    }
+  ]
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_security_policy.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/security_policy) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the module. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if `mode` is panorama, defines the Device Group for the deployment. | `string` | `"shared"` | no |
+| <a name="input_rulebase"></a> [rulebase](#input\_rulebase) | Used if `mode` is panorama, defines the Rulebase for the policy. | `string` | `"pre-rulebase"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if `mode` is ngfw, defines the vsys for the deployment. | `string` | `"vsys1"` | no |
+| <a name="input_rules"></a> [rules](#input\_rules) | List of security rule definitions. The order of the rules will match how they appear in the terraform plan file. Each item supports following parameters:<br>- `name`: (required) The security rule's name.<br>- `description`: (optional) The description of the security rule.<br>- `type`: (optional) Rule type. Valid values are `universal`, `interzone`, or `intrazone` (default: `universal`).<br>- `tags`: (optional) List of administrative tags.<br>- `source_addresses`: (optional) List of source addresses (default: `any`).<br>- `source_zones`: (optional) List of source zones (default: `any`).<br>- `source_users`: (optional) List of source users (default: `any`).<br>- `source_device`: (optional) List of source devices (default: `any`).<br>- `negate_source`: (optional) Boolean designating if the source should be negated (default: `false`).<br>- `hip_profiles`: (optional) List of HIP profiles (default: `any`).<br>- `destination_zones`: (optional) List of destination zones (default: `any`).<br>- `destination_addresses`: (optional) List of destination addresses (default: `any`).<br>- `destination_device`: (optional) List of destination devices (default: `any`).<br>- `negate_destination`: (optional) Boolean designating if the destination should be negated (default: `false`).<br>- `applications`: (optional) List of applications (default: `any`).<br>- `services`: (optional) List of services (default: `application-default`).<br>- `categories`: (optional) List of categories (default: `any`).<br>- `action`: (optional) Action for the matched traffic. Valid values are `allow`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `allow`).<br>- `log_setting`: (optional) Log forwarding profile.<br>- `log_start`: (optional) Boolean designating if log the start of the traffic flow (default: `false`).<br>- `log_end`: (optional) Boolean designating if log the end of the traffic flow (default: `true`).<br>- `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).<br>- `schedule`: (optional) The security rule schedule.<br>- `icmp_unreachable`: (optional) Boolean enabling ICMP unreachable (default: `false`).<br>- `disable_server_response_inspection`: (optional) Boolean disabling server response inspection (default: `false`).<br>- `group`: (optional) Profile setting: `Group` - The group profile name.<br>- `virus`: (optional) Profile setting: `Profiles` - Input the desired antivirus profile name.<br>- `spyware`: (optional) Profile setting: `Profiles` - Input the desired anti-spyware profile name.<br>- `vulnerability`: (optional) Profile setting: `Profiles` - Input the desired vulnerability profile name.<br>- `url_filtering`: (optional) Profile setting: `Profiles` - Input the desired URL filtering profile name.<br>- `file_blocking`: (optional) Profile setting: `Profiles` - Input the desired File-Blocking profile name.<br>- `wildfire_analysis`: (optional) Profile setting: `Profiles` - Input the desired Wildfire Analysis profile name.<br>- `data_filtering`: (optional) Profile setting: `Profiles` - Input the desired Data Filtering profile name.<br>- `audit_comment`: (optional) Comment to apply when the rule is created/updated.<br>- `group_tag`: (optional) Group tag.<br>- `negate_target`: (optional, Panorama only) Instead of applying the rule for the given serial numbers, apply it to everything except them.<br>- `target`: (optional, Panorama only) A target definition,if there are no target sections, then the rule will apply to every vsys of every device in the device group.<br><br>Example:<pre>{<br>  "allow_rule_group" = {<br>    rulebase = "pre-rulebase"<br>    rules = [<br>      {<br>        name = "Allow access to DNS Servers"<br>        tags = [<br>          "Outbound",<br>          "Managed by Terraform"<br>        ]<br>        source_zones                       = ["Trust-L3"]<br>        source_addresses                   = ["RFC1918_Subnets"]<br>        destination_zones                  = ["Untrust-L3"]<br>        destination_addresses              = ["DNS-Servers"]<br>        applications                       = ["dns"]<br>        services                           = ["application-default"]<br>        action                             = "allow"<br>        log_end                            = "true"<br>      },<br>      {<br>        name             = "Allow access to RFC1918"<br>        tags             = ["Managed by Terraform"]<br>        source_zones     = ["Trust-L3"]<br>        source_addresses = ["RFC1918_Subnets"]<br>        destination_zones = [<br>          "Trust-L3",<br>          "Untrust-L3"<br>        ]<br>        destination_addresses              = ["RFC1918_Subnets"]<br>        services                           = ["application-default"]<br>        action                             = "allow"<br>        log_end                            = "true"<br>        virus                              = "default"<br>        spyware                            = "default"<br>        vulnerability                      = "default"<br>      }<br>    ]<br>  }<br>  "block_rule_group" = {<br>    position_keyword = "bottom"<br>    rulebase         = "pre-rulebase"<br>    rules = [<br>      {<br>        name = "Block Some Traffic"<br>        tags = [<br>          "Outbound",<br>          "Managed by Terraform"<br>        ]<br>        source_zones                       = ["Trust-L3"]<br>        source_addresses                   = ["10.0.0.100/32"]<br>        action                             = "deny"<br>        log_end                            = "true"<br>      }<br>    ]<br>  }<br>}</pre> | <pre>list(object({<br>    name                               = string<br>    type                               = optional(string, "universal")<br>    description                        = optional(string)<br>    tags                               = optional(list(string))<br>    source_zones                       = optional(list(string), ["any"])<br>    source_addresses                   = optional(list(string), ["any"])<br>    source_users                       = optional(list(string), ["any"])<br>    source_devices                     = optional(list(string), ["any"])<br>    negate_source                      = optional(string, false)<br>    hip_profiles                       = optional(list(string), ["any"])<br>    destination_zones                  = optional(list(string), ["any"])<br>    destination_addresses              = optional(list(string), ["any"])<br>    destination_devices                = optional(list(string), ["any"])<br>    negate_destination                 = optional(string, false)<br>    applications                       = optional(list(string), ["any"])<br>    services                           = optional(list(string), ["application-default"])<br>    categories                         = optional(list(string), ["any"])<br>    action                             = optional(string, "allow")<br>    log_setting                        = optional(string)<br>    log_start                          = optional(string, false)<br>    log_end                            = optional(string, true)<br>    disabled                           = optional(string, false)<br>    schedule                           = optional(string)<br>    icmp_unreachable                   = optional(string)<br>    disable_server_response_inspection = optional(bool, false)<br>    group                              = optional(string)<br>    virus                              = optional(string)<br>    spyware                            = optional(string)<br>    vulnerability                      = optional(string)<br>    url_filtering                      = optional(string)<br>    file_blocking                      = optional(string)<br>    wildfire_analysis                  = optional(string)<br>    data_filtering                     = optional(string)<br>    audit_comment                      = optional(string)<br>    group_tag                          = optional(string)<br>    negate_target                      = optional(bool, false)<br>    target = optional(list(object({<br>      serial    = string<br>      vsys_list = optional(list(string))<br>    })), null)<br>  }))</pre> | `[]` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_security_policy"></a> [security\_policy](#output\_security\_policy) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/security_policy/main.tf
+++ b/modules/security_policy/main.tf
@@ -1,0 +1,69 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_security_policy" "this" {
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  rulebase     = local.mode_map[var.mode] == 0 ? var.rulebase : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  dynamic "rule" {
+    for_each = var.rules
+
+    content {
+      name                               = rule.value.name
+      description                        = rule.value.description
+      applications                       = rule.value.applications
+      categories                         = rule.value.categories
+      destination_addresses              = rule.value.destination_addresses
+      destination_zones                  = rule.value.destination_zones
+      destination_devices                = rule.value.destination_devices
+      services                           = rule.value.services
+      source_addresses                   = rule.value.source_addresses
+      source_users                       = rule.value.source_users
+      source_zones                       = rule.value.source_zones
+      source_devices                     = rule.value.source_devices
+      hip_profiles                       = rule.value.hip_profiles
+      tags                               = rule.value.tags
+      type                               = rule.value.type
+      negate_source                      = rule.value.negate_source
+      negate_destination                 = rule.value.negate_destination
+      action                             = rule.value.action
+      log_setting                        = rule.value.log_setting
+      log_start                          = rule.value.log_start
+      log_end                            = rule.value.log_end
+      disabled                           = rule.value.disabled
+      schedule                           = rule.value.schedule
+      icmp_unreachable                   = rule.value.icmp_unreachable
+      disable_server_response_inspection = rule.value.disable_server_response_inspection
+      group                              = rule.value.group
+      virus                              = rule.value.virus
+      spyware                            = rule.value.spyware
+      vulnerability                      = rule.value.vulnerability
+      url_filtering                      = rule.value.url_filtering
+      file_blocking                      = rule.value.file_blocking
+      wildfire_analysis                  = rule.value.wildfire_analysis
+      data_filtering                     = rule.value.data_filtering
+      audit_comment                      = rule.value.audit_comment
+      group_tag                          = rule.value.group_tag
+      negate_target                      = rule.value.negate_target
+
+      dynamic "target" {
+        for_each = try(rule.value.target, null) != null ? { for t in rule.value.target : t.serial => t } : {}
+        content {
+          serial    = target.value.serial
+          vsys_list = target.value.vsys_list
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/security_policy/main_test.go
+++ b/modules/security_policy/main_test.go
@@ -1,0 +1,11 @@
+package security_policy
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/security_policy/outputs.tf
+++ b/modules/security_policy/outputs.tf
@@ -1,0 +1,3 @@
+output "security_policy" {
+  value = panos_security_policy.this
+}

--- a/modules/security_policy/variables.tf
+++ b/modules/security_policy/variables.tf
@@ -1,0 +1,189 @@
+variable "mode" {
+  description = "The mode to use for the module. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_group" {
+  description = "Used if `mode` is panorama, defines the Device Group for the deployment."
+  default     = "shared"
+  type        = string
+}
+
+variable "rulebase" {
+  description = "Used if `mode` is panorama, defines the Rulebase for the policy."
+  default     = "pre-rulebase"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if `mode` is ngfw, defines the vsys for the deployment."
+  default     = "vsys1"
+  type        = string
+}
+
+#policy
+variable "rules" {
+  description = <<-EOF
+  List of security rule definitions. The order of the rules will match how they appear in the terraform plan file. Each item supports following parameters:
+  - `name`: (required) The security rule's name.
+  - `description`: (optional) The description of the security rule.
+  - `type`: (optional) Rule type. Valid values are `universal`, `interzone`, or `intrazone` (default: `universal`).
+  - `tags`: (optional) List of administrative tags.
+  - `source_addresses`: (optional) List of source addresses (default: `any`).
+  - `source_zones`: (optional) List of source zones (default: `any`).
+  - `source_users`: (optional) List of source users (default: `any`).
+  - `source_device`: (optional) List of source devices (default: `any`).
+  - `negate_source`: (optional) Boolean designating if the source should be negated (default: `false`).
+  - `hip_profiles`: (optional) List of HIP profiles (default: `any`).
+  - `destination_zones`: (optional) List of destination zones (default: `any`).
+  - `destination_addresses`: (optional) List of destination addresses (default: `any`).
+  - `destination_device`: (optional) List of destination devices (default: `any`).
+  - `negate_destination`: (optional) Boolean designating if the destination should be negated (default: `false`).
+  - `applications`: (optional) List of applications (default: `any`).
+  - `services`: (optional) List of services (default: `application-default`).
+  - `categories`: (optional) List of categories (default: `any`).
+  - `action`: (optional) Action for the matched traffic. Valid values are `allow`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `allow`).
+  - `log_setting`: (optional) Log forwarding profile.
+  - `log_start`: (optional) Boolean designating if log the start of the traffic flow (default: `false`).
+  - `log_end`: (optional) Boolean designating if log the end of the traffic flow (default: `true`).
+  - `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).
+  - `schedule`: (optional) The security rule schedule.
+  - `icmp_unreachable`: (optional) Boolean enabling ICMP unreachable (default: `false`).
+  - `disable_server_response_inspection`: (optional) Boolean disabling server response inspection (default: `false`).
+  - `group`: (optional) Profile setting: `Group` - The group profile name.
+  - `virus`: (optional) Profile setting: `Profiles` - Input the desired antivirus profile name.
+  - `spyware`: (optional) Profile setting: `Profiles` - Input the desired anti-spyware profile name.
+  - `vulnerability`: (optional) Profile setting: `Profiles` - Input the desired vulnerability profile name.
+  - `url_filtering`: (optional) Profile setting: `Profiles` - Input the desired URL filtering profile name.
+  - `file_blocking`: (optional) Profile setting: `Profiles` - Input the desired File-Blocking profile name.
+  - `wildfire_analysis`: (optional) Profile setting: `Profiles` - Input the desired Wildfire Analysis profile name.
+  - `data_filtering`: (optional) Profile setting: `Profiles` - Input the desired Data Filtering profile name.
+  - `audit_comment`: (optional) Comment to apply when the rule is created/updated.
+  - `group_tag`: (optional) Group tag.
+  - `negate_target`: (optional, Panorama only) Instead of applying the rule for the given serial numbers, apply it to everything except them.
+  - `target`: (optional, Panorama only) A target definition,if there are no target sections, then the rule will apply to every vsys of every device in the device group.
+
+  Example:
+  ```
+  {
+    "allow_rule_group" = {
+      rulebase = "pre-rulebase"
+      rules = [
+        {
+          name = "Allow access to DNS Servers"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones                       = ["Trust-L3"]
+          source_addresses                   = ["RFC1918_Subnets"]
+          destination_zones                  = ["Untrust-L3"]
+          destination_addresses              = ["DNS-Servers"]
+          applications                       = ["dns"]
+          services                           = ["application-default"]
+          action                             = "allow"
+          log_end                            = "true"
+        },
+        {
+          name             = "Allow access to RFC1918"
+          tags             = ["Managed by Terraform"]
+          source_zones     = ["Trust-L3"]
+          source_addresses = ["RFC1918_Subnets"]
+          destination_zones = [
+            "Trust-L3",
+            "Untrust-L3"
+          ]
+          destination_addresses              = ["RFC1918_Subnets"]
+          services                           = ["application-default"]
+          action                             = "allow"
+          log_end                            = "true"
+          virus                              = "default"
+          spyware                            = "default"
+          vulnerability                      = "default"
+        }
+      ]
+    }
+    "block_rule_group" = {
+      position_keyword = "bottom"
+      rulebase         = "pre-rulebase"
+      rules = [
+        {
+          name = "Block Some Traffic"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones                       = ["Trust-L3"]
+          source_addresses                   = ["10.0.0.100/32"]
+          action                             = "deny"
+          log_end                            = "true"
+        }
+      ]
+    }
+  }
+  ```
+  EOF
+  default     = []
+  type = list(object({
+    name                               = string
+    type                               = optional(string, "universal")
+    description                        = optional(string)
+    tags                               = optional(list(string))
+    source_zones                       = optional(list(string), ["any"])
+    source_addresses                   = optional(list(string), ["any"])
+    source_users                       = optional(list(string), ["any"])
+    source_devices                     = optional(list(string), ["any"])
+    negate_source                      = optional(string, false)
+    hip_profiles                       = optional(list(string), ["any"])
+    destination_zones                  = optional(list(string), ["any"])
+    destination_addresses              = optional(list(string), ["any"])
+    destination_devices                = optional(list(string), ["any"])
+    negate_destination                 = optional(string, false)
+    applications                       = optional(list(string), ["any"])
+    services                           = optional(list(string), ["application-default"])
+    categories                         = optional(list(string), ["any"])
+    action                             = optional(string, "allow")
+    log_setting                        = optional(string)
+    log_start                          = optional(string, false)
+    log_end                            = optional(string, true)
+    disabled                           = optional(string, false)
+    schedule                           = optional(string)
+    icmp_unreachable                   = optional(string)
+    disable_server_response_inspection = optional(bool, false)
+    group                              = optional(string)
+    virus                              = optional(string)
+    spyware                            = optional(string)
+    vulnerability                      = optional(string)
+    url_filtering                      = optional(string)
+    file_blocking                      = optional(string)
+    wildfire_analysis                  = optional(string)
+    data_filtering                     = optional(string)
+    audit_comment                      = optional(string)
+    group_tag                          = optional(string)
+    negate_target                      = optional(bool, false)
+    target = optional(list(object({
+      serial    = string
+      vsys_list = optional(list(string))
+    })), null)
+  }))
+  validation {
+    condition = alltrue([
+      for rule in var.rules :
+      contains(["universal", "interzone", "intrazone"], coalesce(rule.type, "universal"))
+    ])
+    error_message = "Valid types of type are `universal`, `interzone`, `intrazone`"
+  }
+  validation {
+    condition = alltrue([
+      for rule in var.rules :
+      contains([
+        "allow", "deny", "drop", "reset-client", "reset-server", "reset-both"
+      ], coalesce(rule.action, "allow"))
+    ])
+    error_message = "Valid types of action are `allow`, `deny`, `drop`, `reset-client`, `reset-server`, `reset-both`"
+  }
+}

--- a/modules/security_policy/versions.tf
+++ b/modules/security_policy/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/security_profiles/README.md
+++ b/modules/security_profiles/README.md
@@ -1,0 +1,210 @@
+Palo Alto Networks PAN-OS Security Profiles Module
+---
+This Terraform module allows users to configure security profiles.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "security_profiles" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/security_profiles"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group = "test"
+
+  antivirus_profiles = {
+    test-av-profile = {
+      decoders = [
+        {
+          name = "http"
+        }
+      ]
+      application_exceptions = [
+        { application = "atmail" },
+        { application = "alisoft" }
+      ]
+      machine_learning_models = [
+        {
+          model  = "Windows Executables"
+          action = "disable"
+        }
+      ]
+      machine_learning_exceptions = [
+        {
+          name = "my-exception"
+        },
+        {
+          name        = "sample-virus"
+          filename    = "test-virus-file"
+          description = "Test virus file"
+        }
+      ]
+    }
+  }
+  antispyware_profiles = {
+    test-antispyware = {
+      rules = [
+        {
+          name              = "test-policy"
+          action            = "block-ip"
+          block_ip_duration = 60
+        }
+      ]
+    }
+  }
+  file_blocking_profiles = {
+    outbound-test = {
+      rules = [
+        {
+          name         = "Alert-All"
+          applications = ["any"]
+          file_types   = ["any"]
+          direction    = "both"
+          action       = "alert"
+        },
+        {
+          name         = "Block"
+          applications = ["any"]
+          file_types = [
+            "7z",
+            "bat",
+            "chm",
+            "class",
+            "cpl",
+            "dll",
+            "hlp",
+            "hta",
+            "jar",
+            "ocx",
+            "pif",
+            "scr",
+            "torrent",
+            "vbe",
+            "wsf"
+          ]
+          direction = "both"
+          action    = "block"
+        }
+      ]
+    }
+  }
+  vulnerability_protection_profiles = {
+    outbound-test = {
+      rules = [
+        {
+          name           = "Block-Critical-High-Medium"
+          action         = "reset-both"
+          vendor_ids     = ["any"]
+          severities     = ["critical", "high", "medium"]
+          cves           = ["any"]
+          threat_name    = "any"
+          host           = "any"
+          category       = "any"
+          packet_capture = "single-packet"
+        },
+        {
+          name           = "Default-Low-Info"
+          action         = "default"
+          vendor_ids     = ["any"]
+          severities     = ["low", "informational"]
+          cves           = ["any"]
+          threat_name    = "any"
+          host           = "any"
+          category       = "any"
+          packet_capture = "disable"
+        }
+      ]
+    }
+  }
+  wildfire_analysis_profiles = {
+    outbound-test = {
+      rules = [
+        {
+          name         = "Forward-All"
+          applications = ["any"]
+          file_types   = ["any"]
+          direction    = "both"
+          analysis     = "public-cloud"
+        }
+      ]
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_anti_spyware_security_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/anti_spyware_security_profile) | resource |
+| [panos_antivirus_security_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/antivirus_security_profile) | resource |
+| [panos_file_blocking_security_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/file_blocking_security_profile) | resource |
+| [panos_vulnerability_security_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/vulnerability_security_profile) | resource |
+| [panos_wildfire_analysis_security_profile.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/wildfire_analysis_security_profile) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the module. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if `mode` is `panorama`, this defines the Device Group for the deployment. | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if `mode` is `ngfw`, this defines the vsys for the deployment. | `string` | `"vsys1"` | no |
+| <a name="input_antivirus_profiles"></a> [antivirus\_profiles](#input\_antivirus\_profiles) | List with the Antivirus profile objects. Each item supports following parameters:<br>- `name`: (required) Profile name.<br>- `description`: (optional) Profile description.<br>- `packet_capture`: (optional) Boolean that enables packet capture (default: `false`).<br>- `threat_exceptions`: (optional) A string list of threat exceptions.<br>- `decoders`: (optional) List of objects following the decoder specifications.<br>  - `name`: (required) Decoder name.<br>  - `actions`: (optional) Decoder action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).<br>  - `wildfire_action`: (optional) Wildfire action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).<br>  - `machine_learning_action`: (optional) Only available with PAN-OS 10.0+, machine learning action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).<br>- `application_exceptions`: (optional) List of objects following the application exception specifications.<br>  - `application`: (required) The application name.<br>  - `action`: (optional) The action performed when approached with the application exception. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).<br>- `machine_learning_models`: (optional) List of objects following the machine learning model specifications.<br>  - `model`: (required) The model.<br>  - `action`: (required) The action for the machine learning model to perform. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).<br>- `machine_learning_exceptions`: (optional) List of objects following the machine learning exception specifications.<br>  - `name`: (required) Partial hash of file included in the machine learning exception.<br>  - `description`: (optional) The description of the exception.<br>  - `filename`: (optional) The filename for the exception<br>Example:<pre>[<br>  {<br>    name = "Alert-Only-AV"<br>    decoders = [<br>      {<br>        name = "http"<br>        action = "alert"<br>        wildfire_action = "alert"<br>        machine_learning = "alert"<br>      }<br>    ]<br>    machine_learning_models = [<br>      {<br>        model = "Windows Executables"<br>        action = "enable"<br>      },<br>      {<br>        model = "PowerShell Script 1"<br>        action = "enable"<br>      }<br>    ]<br>  }<br>]</pre> | <pre>map(object({<br>    description       = optional(string)<br>    packet_capture    = optional(bool)<br>    threat_exceptions = optional(list(string))<br>    decoders = optional(list(object({<br>      name                    = string<br>      action                  = optional(string, "default")<br>      wildfire_action         = optional(string, "default")<br>      machine_learning_action = optional(string, "default")<br>    })), [])<br>    application_exceptions = optional(list(object({<br>      application = string<br>      action      = optional(string, "default")<br>    })), [])<br>    machine_learning_models = optional(list(object({<br>      model  = string<br>      action = string<br>    })), [])<br>    machine_learning_exceptions = optional(list(object({<br>      name        = string<br>      description = optional(string)<br>      filename    = optional(string)<br>    })), [])<br>  }))</pre> | `{}` | no |
+| <a name="input_antispyware_profiles"></a> [antispyware\_profiles](#input\_antispyware\_profiles) | List of the Anti-Spyware profile objects. Each item supports following parameters:<br>- `name`: (required) Identifier of the Anti-Spyware security profile.<br>- `description`: (optional) The description of the Anti-Spyware profile.<br>- `packet_capture`: (optional) Packet capture setting for PAN-OS 8.X only). Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).<br>- `sinkhole_ipv4_address`: (optional) IPv4 sinkhole address.<br>- `sinkhole_ipv6_address`: (optional) IPv6 sinkhole address.<br>- `threat_exceptions`: (optional) A string list of threat exceptions.<br>- `botnet_lists`: (optional) List of objects following the botnet specifications.<br>  - `name`: (required) Botnet name.<br>  - `actions`: (optional) Botnet action. Valid values are `allow`, `alert`, `block`, `default`, or `sinkhole` (default: `default`).<br>  - `packet_capture`: (optional) Packet capture setting for PAN-OS 9.0+. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).<br>- `dns_categories`: (optional) List of objects following the DNS category specifications for PAN-OS 10.0+.<br>  - `name`: (required) DNS category name.<br>  - `action`: (optional) DNS category action. Valid values are `default`, `allow`, `alert`, `drop`, `block`, or `sinkhole` (default: `default`).<br>  - `log_level`: (optional) Logging level. Valid values are `default`, `none`, `low`, `informational`, `medium`, `high`, or `critical` (default: `default`).<br>  - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).<br>- `white_lists`: (optional) List of objects following the white list specifications.<br>  - `name`: (required) White list object name.<br>  - `description`: (optional) Description of the white list.<br>- `rules`: (optional) List of objects following the rule specifications.<br>  - `name`: (required) Rule name.<br>  - `threat_name`: (optional) Threat name.<br>  - `category`: (optional) Category for the anti-spyware policy (default: `any`).<br>  - `severities`: (optional) List of severities to include in policy. Valid values are `any`, `critical`, `high`, `medium`, `low`, or/and `informational` (default: `any`).<br>  - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).<br>  - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.<br>  - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.<br>- `exceptions`: (optional) List of objects following the exceptions specifications.<br>  - `name`: (required) Threat name for the exception. You can use the `panos_predefined_threat` data source to discover the various names available to use.<br>  - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).<br>  - `action`: (optional) Exception action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, `reset-both`, or `block-ip` (default: `default`).<br>  - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.<br>  - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.<br>  - `exempt_ips`: (optional) List of exempt IPs.<br><br>Example:<pre>[<br>  {<br><br>    name = "Outbound-AS"<br>    botnet_lists = [<br>      {<br>        name = "default-paloalto-dns"<br>        action = "sinkhole"<br>        packet_capture = "single-packet"<br>      }<br>    ]<br>    dns_categories = [<br>      {<br>        name = "pan-dns-sec-benign"<br>      },<br>      {<br>        name = "pan-dns-sec-cc"<br>        action = "sinkhole"<br>        packet_capture = "single-packet"<br>      }<br>    ]<br>    sinkhole_ipv4_address = "72.5.65.111"<br>    sinkhole_ipv6_address = "2600:5200::1"<br>    rules =<br>    [<br>      {<br>        name = "Block-Critical-High-Medium"<br>        action = "reset-both"<br>        severities = ["critical","high","medium"]<br>        packet_capture = "single-packet"<br>      },<br>      {<br>        name = "Default-Low-Info"<br>        severities = ["low","informational"]<br>        packet_capture = "disable"<br>      }<br>    ]<br>  }<br>]</pre> | <pre>map(object({<br>    description           = optional(string)<br>    packet_capture        = optional(string, "disable")<br>    sinkhole_ipv4_address = optional(string)<br>    sinkhole_ipv6_address = optional(string)<br>    threat_exceptions     = optional(list(string))<br>    botnet_lists = optional(list(object({<br>      name           = string<br>      action         = optional(string, "default")<br>      packet_capture = optional(string, "disable")<br>    })), [])<br>    dns_categories = optional(list(object({<br>      name           = string<br>      action         = optional(string, "default")<br>      log_level      = optional(string, "default")<br>      packet_capture = optional(string, "disable")<br>    })), [])<br>    white_lists = optional(list(object({<br>      name        = string<br>      description = optional(string)<br>    })), [])<br>    rules = optional(list(object({<br>      name              = string<br>      threat_name       = optional(string, "any")<br>      category          = optional(string, "any")<br>      severities        = optional(list(string), ["any"])<br>      packet_capture    = optional(string, "disable")<br>      action            = optional(string, "default")<br>      block_ip_track_by = optional(string, "source")<br>      block_ip_duration = optional(number)<br>    })), [])<br>    exceptions = optional(list(object({<br>      name              = string<br>      packet_capture    = optional(string, "disable")<br>      action            = optional(string, "default")<br>      block_ip_track_by = optional(string, "source")<br>      block_ip_duration = optional(number)<br>      exempt_ips        = optional(list(string))<br>    })), [])<br>  }))</pre> | `{}` | no |
+| <a name="input_file_blocking_profiles"></a> [file\_blocking\_profiles](#input\_file\_blocking\_profiles) | List of the File Blocking profile objects. Each item supports following parameters:<br>- `name`: (required) Identifier of the File-blocking security profile.<br>- `description`: (optional) The description of the File-blocking profile.<br>- `rules`: (optional) List of objects following the rule specifications.<br>  - `name`: (required) Rule name.<br>  - `applications`: (optional) List of applications (default: `any`).<br>  - `file_types`: (optional) File types included in the file-blocking rule.<br>  - `direction`: (optional) Direction for the file-blocking rule to flow. Valid values are `both`, `upload`, or `download` (default: `both`).<br>  - `action`: (optional) Action for the policy to take. Valid values are `alert`, `block`, or `continue` (default: `alert`).<br><br>Example:<pre>[<br>  {<br>    name = "Outbound-FB"<br>    rules = [<br>      {<br>        name = "Alert-All"<br>        applications = ["any"]<br>        file_types = ["any"]<br>        direction = "both"<br>        action = "alert"<br>      },<br>      {<br>        name = "Block"<br>        applications = ["any"]<br>        file_types = [<br>          "7z",<br>          "bat",<br>          "chm",<br>          "class",<br>          "cpl",<br>          "dll",<br>          "hlp",<br>          "hta",<br>          "jar",<br>          "ocx",<br>          "pif",<br>          "scr",<br>          "torrent",<br>          "vbe",<br>          "wsf"<br>        ]<br>        direction = "both"<br>        action = "block"<br>      }<br>    ]<br>  }<br>]</pre> | <pre>map(object({<br>    description = optional(string)<br>    rules = optional(list(object({<br>      name         = string<br>      applications = optional(list(string), ["any"])<br>      file_types   = optional(list(string), ["any"])<br>      direction    = optional(string, "both")<br>      action       = optional(string, "alert")<br>    })), [])<br>  }))</pre> | `{}` | no |
+| <a name="input_vulnerability_protection_profiles"></a> [vulnerability\_protection\_profiles](#input\_vulnerability\_protection\_profiles) | List of the Vulnerability Protection profile objects. Each item supports following parameters:<br>- `name`: (required) Identifier of the Vulnerability security profile.<br>- `description`: (optional) The description of the vulnerability profile.<br>- `rules`: (optional) List of objects following the rule specifications.<br>  - `name`: (required) Rule name.<br>  - `threat_name`: (optional) Threat name.<br>  - `cves`: (optional) List of CVEs (default: `any`).<br>  - `host`: (optional) The host. Valid values are `any`, `client`, or `server` (default: `any`).<br>  - `vendor_ids`: (optional) List of vendor IDs (default: `any`).<br>  - `category`: (optional) Category for the file-blocking policy (default: `any`).<br>  - `severities`: (optional) List of severities to include in policy. Valid values are `any`, `critical`, `high`, `medium`, `low`, or/and `informational` (default: `any`).<br>  - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).<br>  - `action`: (optional) Exception action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, `reset-both`, or `block-ip` (default: `default`).<br>  - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.<br>  - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.<br>- `exceptions`: (optional) List of objects following the exceptions specifications.<br>  - `name`: (required) Threat name for the exception. You can use the `panos_predefined_threat` data source to discover the various names available to use.<br>  - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).<br>  - `action`: (optional) Exception action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, `reset-both`, or `block-ip` (default: `default`).<br>  - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.<br>  - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.<br>  - `exempt_ips`: (optional) List of exempt IPs.<br>  - `time_interval`: (optional) Time interval integer.<br>  - `time_threshold`: (optional) Time threshold integer.<br>  - `time_track_by`: (optional) Time track by setting. Valid values are `source`, `destination`, or `source-and-destination`.<br><br>Example:<pre>[<br>  {<br>    name = "Outbound-VP"<br>    rules = [<br>      {<br>        name = "Block-Critical-High-Medium"<br>        action = "reset-both"<br>        vendor_ids = ["any"]<br>        severities = ["critical","high","medium"]<br>        cves = ["any"]<br>        threat_name = "any"<br>        host = "any"<br>        category = "any"<br>        packet_capture = "single-packet"<br>      },<br>      {<br>        name = "Default-Low-Info"<br>        action = "default"<br>        vendor_ids = ["any"]<br>        severities = ["low","informational"]<br>        cves = ["any"]<br>        threat_name = "any"<br>        host = "any"<br>        category = "any"<br>        packet_capture = "disable"<br>      }<br>    ]<br>  }<br>]</pre> | <pre>map(object({<br>    description = optional(string)<br>    rules = optional(list(object({<br>      name              = string<br>      threat_name       = optional(string, "any")<br>      cves              = optional(set(string), ["any"])<br>      host              = optional(string, "any")<br>      vendor_ids        = optional(set(string), ["any"])<br>      severities        = optional(list(string), ["any"])<br>      category          = optional(string, "any")<br>      action            = optional(string, "default")<br>      block_ip_track_by = optional(string, "source")<br>      block_ip_duration = optional(number)<br>      packet_capture    = optional(string, "disable")<br>    })), [])<br>    exceptions = optional(list(object({<br>      name              = string<br>      packet_capture    = optional(string, "disable")<br>      action            = optional(string, "default")<br>      block_ip_track_by = optional(string, "source")<br>      block_ip_duration = optional(number)<br>      time_interval     = optional(number)<br>      time_threshold    = optional(number)<br>      time_track_by     = optional(string)<br>      exempt_ips        = optional(list(string))<br>    })), [])<br>  }))</pre> | `{}` | no |
+| <a name="input_wildfire_analysis_profiles"></a> [wildfire\_analysis\_profiles](#input\_wildfire\_analysis\_profiles) | List of the Wildfire Analysis profile objects. Each item supports following parameters:<br>- `name`: (required) Identifier of the Wildfire Analysis security profile.<br>- `device_group`: (optional) The device group location (default: `shared`).<br>- `description`: (optional) The description of the Wildfire Analysis profile.<br>- `rules`: (optional) List of objects following the rule specifications.<br>  - `name`: (required) Rule name.<br>  - `applications`: (optional) List of applications (default: `any`).<br>  - `file_types`: (optional) List of file types (default: `any`).<br>  - `direction`: (optional) Direction for the wildfire analysis policy. Valid values are `both`, `upload`, or `download` (default: `both`).<br>  - `analysis`: (optional) Analysis setting. Valid values are `public-cloud` or `private-cloud` (default: `public-cloud`).<br><br>Example:<pre>[<br>  {<br>    name = "Outbound-WF"<br>    rules = [<br>      {<br>        name = "Forward-All"<br>        applications = ["any"]<br>        file_types = ["any"]<br>        direction = "both"<br>        analysis = "public-cloud"<br>      }<br>    ]<br>  }<br>]</pre> | <pre>map(object({<br>    description = optional(string)<br>    rules = optional(list(object({<br>      name         = string<br>      applications = optional(list(string), ["any"])<br>      file_types   = optional(list(string), ["any"])<br>      direction    = optional(string, "both")<br>      analysis     = optional(string, "public-cloud")<br>    })), [])<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panos_antivirus_security_profile"></a> [panos\_antivirus\_security\_profile](#output\_panos\_antivirus\_security\_profile) | n/a |
+| <a name="output_panos_anti_spyware_security_profile"></a> [panos\_anti\_spyware\_security\_profile](#output\_panos\_anti\_spyware\_security\_profile) | n/a |
+| <a name="output_panos_file_blocking_security_profile"></a> [panos\_file\_blocking\_security\_profile](#output\_panos\_file\_blocking\_security\_profile) | n/a |
+| <a name="output_panos_vulnerability_security_profile"></a> [panos\_vulnerability\_security\_profile](#output\_panos\_vulnerability\_security\_profile) | n/a |
+| <a name="output_panos_wildfire_analysis_security_profile"></a> [panos\_wildfire\_analysis\_security\_profile](#output\_panos\_wildfire\_analysis\_security\_profile) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/security_profiles/main.tf
+++ b/modules/security_profiles/main.tf
@@ -1,0 +1,242 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+# Antivirus profiles
+resource "panos_antivirus_security_profile" "this" {
+  for_each = var.antivirus_profiles
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  name              = each.key
+  description       = each.value.description
+  packet_capture    = each.value.packet_capture
+  threat_exceptions = each.value.threat_exceptions
+
+  dynamic "decoder" {
+    for_each = each.value.decoders
+
+    content {
+      name                    = decoder.value.name
+      action                  = decoder.value.action
+      wildfire_action         = decoder.value.wildfire_action
+      machine_learning_action = decoder.value.machine_learning_action
+    }
+  }
+
+  dynamic "application_exception" {
+    for_each = each.value.application_exceptions
+
+    content {
+      application = application_exception.value.application
+      action      = application_exception.value.action
+    }
+  }
+
+  dynamic "machine_learning_model" {
+    for_each = each.value.machine_learning_models
+
+    content {
+      model  = machine_learning_model.value.model
+      action = machine_learning_model.value.action
+    }
+  }
+
+  dynamic "machine_learning_exception" {
+    for_each = each.value.machine_learning_exceptions
+
+    content {
+      name        = machine_learning_exception.value.name
+      description = machine_learning_exception.value.description
+      filename    = machine_learning_exception.value.filename
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Anti-spyware profiles
+resource "panos_anti_spyware_security_profile" "this" {
+  for_each = var.antispyware_profiles
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  name                  = each.key
+  description           = each.value.description
+  sinkhole_ipv4_address = each.value.sinkhole_ipv4_address
+  sinkhole_ipv6_address = each.value.sinkhole_ipv6_address
+  threat_exceptions     = each.value.threat_exceptions
+
+  dynamic "botnet_list" {
+    for_each = each.value.botnet_lists
+
+    content {
+      name           = botnet_list.value.name
+      action         = botnet_list.value.action
+      packet_capture = botnet_list.value.packet_capture
+    }
+  }
+
+  dynamic "dns_category" {
+    for_each = each.value.dns_categories
+
+    content {
+      name           = dns_category.value.name
+      action         = dns_category.value.action
+      log_level      = dns_category.value.log_level
+      packet_capture = dns_category.value.packet_capture
+    }
+  }
+
+  dynamic "white_list" {
+    for_each = each.value.white_lists
+
+    content {
+      name        = white_list.value.name
+      description = white_list.value.description
+    }
+  }
+
+  dynamic "rule" {
+    for_each = each.value.rules
+
+    content {
+      name              = rule.value.name
+      threat_name       = rule.value.threat_name
+      severities        = rule.value.severities
+      category          = rule.value.category
+      action            = rule.value.action
+      packet_capture    = rule.value.packet_capture
+      block_ip_track_by = rule.value.action == "block-ip" ? rule.value.block_ip_track_by : null
+      block_ip_duration = rule.value.action == "block-ip" ? rule.value.block_ip_duration : null
+    }
+  }
+
+  dynamic "exception" {
+    for_each = each.value.exceptions
+
+    content {
+      name              = exception.value.name
+      action            = exception.value.action
+      block_ip_track_by = exception.value.action == "block-ip" ? exception.value.block_ip_track_by : null
+      block_ip_duration = exception.value.action == "block-ip" ? exception.value.block_ip_duration : null
+      packet_capture    = exception.value.packet_capture
+      exempt_ips        = exception.value.exempt_ips
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# File Blocking profiles
+resource "panos_file_blocking_security_profile" "this" {
+  for_each = var.file_blocking_profiles
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  name        = each.key
+  description = try(each.value.description, null)
+
+  dynamic "rule" {
+    for_each = each.value.rules
+
+    content {
+      name         = rule.value.name
+      applications = rule.value.applications
+      file_types   = rule.value.file_types
+      direction    = rule.value.direction
+      action       = rule.value.action
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Vulnerability Protection profiles
+resource "panos_vulnerability_security_profile" "this" {
+  for_each = var.vulnerability_protection_profiles
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  name        = each.key
+  description = try(each.value.description, null)
+
+  dynamic "rule" {
+    for_each = each.value.rules
+
+    content {
+      name              = rule.value.name
+      threat_name       = rule.value.threat_name
+      cves              = rule.value.cves
+      host              = rule.value.host
+      vendor_ids        = rule.value.vendor_ids
+      severities        = rule.value.severities
+      category          = rule.value.category
+      action            = rule.value.action
+      block_ip_track_by = rule.value.action == "block-ip" ? rule.value.block_ip_track_by : null
+      block_ip_duration = rule.value.action == "block-ip" ? rule.value.block_ip_duration : null
+      packet_capture    = rule.value.packet_capture
+    }
+  }
+
+  dynamic "exception" {
+    for_each = each.value.exceptions
+
+    content {
+      name              = exception.value.name
+      action            = exception.value.action
+      block_ip_track_by = exception.value.action == "block-ip" ? exception.value.block_ip_track_by : null
+      block_ip_duration = exception.value.action == "block-ip" ? exception.value.block_ip_duration : null
+      packet_capture    = exception.value.packet_capture
+      time_interval     = exception.value.time_interval
+      time_threshold    = exception.value.time_threshold
+      time_track_by     = exception.value.time_track_by
+      exempt_ips        = exception.value.exempt_ips
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# WildFire Analysis profiles
+resource "panos_wildfire_analysis_security_profile" "this" {
+  for_each = var.wildfire_analysis_profiles
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  name        = each.key
+  description = try(each.value.description, null)
+
+  dynamic "rule" {
+    for_each = each.value.rules
+
+    content {
+      name         = rule.value.name
+      applications = rule.value.applications
+      file_types   = rule.value.file_types
+      direction    = rule.value.direction
+      analysis     = rule.value.analysis
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/security_profiles/main_test.go
+++ b/modules/security_profiles/main_test.go
@@ -1,0 +1,11 @@
+package security_profiles
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/security_profiles/outputs.tf
+++ b/modules/security_profiles/outputs.tf
@@ -1,0 +1,19 @@
+output "panos_antivirus_security_profile" {
+  value = panos_antivirus_security_profile.this
+}
+
+output "panos_anti_spyware_security_profile" {
+  value = panos_anti_spyware_security_profile.this
+}
+
+output "panos_file_blocking_security_profile" {
+  value = panos_file_blocking_security_profile.this
+}
+
+output "panos_vulnerability_security_profile" {
+  value = panos_vulnerability_security_profile.this
+}
+
+output "panos_wildfire_analysis_security_profile" {
+  value = panos_wildfire_analysis_security_profile.this
+}

--- a/modules/security_profiles/variables.tf
+++ b/modules/security_profiles/variables.tf
@@ -1,0 +1,660 @@
+variable "mode" {
+  description = "The mode to use for the module. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either 'panorama' or 'ngfw'."
+  }
+}
+
+variable "device_group" {
+  description = "Used if `mode` is `panorama`, this defines the Device Group for the deployment."
+  default     = "shared"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if `mode` is `ngfw`, this defines the vsys for the deployment."
+  default     = "vsys1"
+  type        = string
+}
+
+variable "antivirus_profiles" {
+  description = <<-EOF
+  List with the Antivirus profile objects. Each item supports following parameters:
+  - `name`: (required) Profile name.
+  - `description`: (optional) Profile description.
+  - `packet_capture`: (optional) Boolean that enables packet capture (default: `false`).
+  - `threat_exceptions`: (optional) A string list of threat exceptions.
+  - `decoders`: (optional) List of objects following the decoder specifications.
+    - `name`: (required) Decoder name.
+    - `actions`: (optional) Decoder action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).
+    - `wildfire_action`: (optional) Wildfire action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).
+    - `machine_learning_action`: (optional) Only available with PAN-OS 10.0+, machine learning action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).
+  - `application_exceptions`: (optional) List of objects following the application exception specifications.
+    - `application`: (required) The application name.
+    - `action`: (optional) The action performed when approached with the application exception. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).
+  - `machine_learning_models`: (optional) List of objects following the machine learning model specifications.
+    - `model`: (required) The model.
+    - `action`: (required) The action for the machine learning model to perform. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `default`).
+  - `machine_learning_exceptions`: (optional) List of objects following the machine learning exception specifications.
+    - `name`: (required) Partial hash of file included in the machine learning exception.
+    - `description`: (optional) The description of the exception.
+    - `filename`: (optional) The filename for the exception
+  Example:
+  ```
+  [
+    {
+      name = "Alert-Only-AV"
+      decoders = [
+        {
+          name = "http"
+          action = "alert"
+          wildfire_action = "alert"
+          machine_learning = "alert"
+        }
+      ]
+      machine_learning_models = [
+        {
+          model = "Windows Executables"
+          action = "enable"
+        },
+        {
+          model = "PowerShell Script 1"
+          action = "enable"
+        }
+      ]
+    }
+  ]
+  ```
+  EOF
+
+  default = {}
+  type = map(object({
+    description       = optional(string)
+    packet_capture    = optional(bool)
+    threat_exceptions = optional(list(string))
+    decoders = optional(list(object({
+      name                    = string
+      action                  = optional(string, "default")
+      wildfire_action         = optional(string, "default")
+      machine_learning_action = optional(string, "default")
+    })), [])
+    application_exceptions = optional(list(object({
+      application = string
+      action      = optional(string, "default")
+    })), [])
+    machine_learning_models = optional(list(object({
+      model  = string
+      action = string
+    })), [])
+    machine_learning_exceptions = optional(list(object({
+      name        = string
+      description = optional(string)
+      filename    = optional(string)
+    })), [])
+  }))
+
+  validation {
+    condition = alltrue([
+      for profile in var.antivirus_profiles : alltrue([
+        for decoder in profile.decoders : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both"], decoder.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antivirus_profiles : alltrue([
+        for decoder in profile.decoders : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both"], decoder.wildfire_action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antivirus_profiles : alltrue([
+        for decoder in profile.decoders : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both"], decoder.machine_learning_action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antivirus_profiles : alltrue([
+        for app_exception in profile.application_exceptions : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both"], app_exception.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antivirus_profiles : alltrue([
+        for ml_model in profile.machine_learning_models : contains(["enable", "alert-only", "disable"], ml_model.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'enable', 'alert-only', 'disable'."
+  }
+}
+
+variable "antispyware_profiles" {
+  description = <<-EOF
+  List of the Anti-Spyware profile objects. Each item supports following parameters:
+  - `name`: (required) Identifier of the Anti-Spyware security profile.
+  - `description`: (optional) The description of the Anti-Spyware profile.
+  - `packet_capture`: (optional) Packet capture setting for PAN-OS 8.X only). Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).
+  - `sinkhole_ipv4_address`: (optional) IPv4 sinkhole address.
+  - `sinkhole_ipv6_address`: (optional) IPv6 sinkhole address.
+  - `threat_exceptions`: (optional) A string list of threat exceptions.
+  - `botnet_lists`: (optional) List of objects following the botnet specifications.
+    - `name`: (required) Botnet name.
+    - `actions`: (optional) Botnet action. Valid values are `allow`, `alert`, `block`, `default`, or `sinkhole` (default: `default`).
+    - `packet_capture`: (optional) Packet capture setting for PAN-OS 9.0+. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).
+  - `dns_categories`: (optional) List of objects following the DNS category specifications for PAN-OS 10.0+.
+    - `name`: (required) DNS category name.
+    - `action`: (optional) DNS category action. Valid values are `default`, `allow`, `alert`, `drop`, `block`, or `sinkhole` (default: `default`).
+    - `log_level`: (optional) Logging level. Valid values are `default`, `none`, `low`, `informational`, `medium`, `high`, or `critical` (default: `default`).
+    - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).
+  - `white_lists`: (optional) List of objects following the white list specifications.
+    - `name`: (required) White list object name.
+    - `description`: (optional) Description of the white list.
+  - `rules`: (optional) List of objects following the rule specifications.
+    - `name`: (required) Rule name.
+    - `threat_name`: (optional) Threat name.
+    - `category`: (optional) Category for the anti-spyware policy (default: `any`).
+    - `severities`: (optional) List of severities to include in policy. Valid values are `any`, `critical`, `high`, `medium`, `low`, or/and `informational` (default: `any`).
+    - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).
+    - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.
+    - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.
+  - `exceptions`: (optional) List of objects following the exceptions specifications.
+    - `name`: (required) Threat name for the exception. You can use the `panos_predefined_threat` data source to discover the various names available to use.
+    - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).
+    - `action`: (optional) Exception action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, `reset-both`, or `block-ip` (default: `default`).
+    - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.
+    - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.
+    - `exempt_ips`: (optional) List of exempt IPs.
+
+  Example:
+  ```
+  [
+    {
+
+      name = "Outbound-AS"
+      botnet_lists = [
+        {
+          name = "default-paloalto-dns"
+          action = "sinkhole"
+          packet_capture = "single-packet"
+        }
+      ]
+      dns_categories = [
+        {
+          name = "pan-dns-sec-benign"
+        },
+        {
+          name = "pan-dns-sec-cc"
+          action = "sinkhole"
+          packet_capture = "single-packet"
+        }
+      ]
+      sinkhole_ipv4_address = "72.5.65.111"
+      sinkhole_ipv6_address = "2600:5200::1"
+      rules =
+      [
+        {
+          name = "Block-Critical-High-Medium"
+          action = "reset-both"
+          severities = ["critical","high","medium"]
+          packet_capture = "single-packet"
+        },
+        {
+          name = "Default-Low-Info"
+          severities = ["low","informational"]
+          packet_capture = "disable"
+        }
+      ]
+    }
+  ]
+  ```
+  EOF
+
+  default = {}
+  type = map(object({
+    description           = optional(string)
+    packet_capture        = optional(string, "disable")
+    sinkhole_ipv4_address = optional(string)
+    sinkhole_ipv6_address = optional(string)
+    threat_exceptions     = optional(list(string))
+    botnet_lists = optional(list(object({
+      name           = string
+      action         = optional(string, "default")
+      packet_capture = optional(string, "disable")
+    })), [])
+    dns_categories = optional(list(object({
+      name           = string
+      action         = optional(string, "default")
+      log_level      = optional(string, "default")
+      packet_capture = optional(string, "disable")
+    })), [])
+    white_lists = optional(list(object({
+      name        = string
+      description = optional(string)
+    })), [])
+    rules = optional(list(object({
+      name              = string
+      threat_name       = optional(string, "any")
+      category          = optional(string, "any")
+      severities        = optional(list(string), ["any"])
+      packet_capture    = optional(string, "disable")
+      action            = optional(string, "default")
+      block_ip_track_by = optional(string, "source")
+      block_ip_duration = optional(number)
+    })), [])
+    exceptions = optional(list(object({
+      name              = string
+      packet_capture    = optional(string, "disable")
+      action            = optional(string, "default")
+      block_ip_track_by = optional(string, "source")
+      block_ip_duration = optional(number)
+      exempt_ips        = optional(list(string))
+    })), [])
+  }))
+
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : contains(["", "disable", "single-packet", "extended-capture"], profile.packet_capture)
+    ])
+    error_message = "Valid 'packet_capture' values are: 'disable', 'single-packet', 'extended-capture'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for botnet_list in profile.botnet_lists : contains(["default", "allow", "alert", "block", "sinkhole"], botnet_list.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'block', 'sinkhole'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for botnet_list in profile.botnet_lists : contains(["disable", "single-packet", "extended-capture"], botnet_list.packet_capture)
+      ])
+    ])
+    error_message = "Valid 'packet_capture' values are: 'disable', 'single-packet', 'extended-capture'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for dns_category in profile.dns_categories : contains(["default", "allow", "alert", "block", "sinkhole"], dns_category.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'block', 'sinkhole'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for dns_category in profile.dns_categories : contains(["default", "none", "low", "informational", "medium", "high", "critical"], dns_category.log_level)
+      ])
+    ])
+    error_message = "Valid log levels are: 'default', 'none', 'low', 'informational', 'medium', 'high', 'critical'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for dns_category in profile.dns_categories : contains(["disable", "single-packet", "extended-capture"], dns_category.packet_capture)
+      ])
+    ])
+    error_message = "Valid 'packet_capture' values are: 'disable', 'single-packet', 'extended-capture'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for rule in profile.rules : contains(["disable", "single-packet", "extended-capture"], rule.packet_capture)
+      ])
+    ])
+    error_message = "Valid 'packet_capture' values are: 'disable', 'single-packet', 'extended-capture'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for rule in profile.rules : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both", "block-ip"], rule.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both', 'block-ip'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for rule in profile.rules : contains(["source", "source-and-destination"], rule.block_ip_track_by)
+      ])
+    ])
+    error_message = "Valid 'block_ip_track_by' values are: 'source', 'source-and-destination'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for exception in profile.exceptions : contains(["disable", "single-packet", "extended-capture"], exception.packet_capture)
+      ])
+    ])
+    error_message = "Valid 'packet_capture' values are: 'disable', 'single-packet', 'extended-capture'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for exception in profile.exceptions : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both", "block-ip"], exception.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both', 'block-ip'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.antispyware_profiles : alltrue([
+        for exception in profile.exceptions : contains(["source", "source-and-destination"], exception.block_ip_track_by)
+      ])
+    ])
+    error_message = "Valid 'block_ip_track_by' values are: 'source', 'source-and-destination'."
+  }
+}
+
+variable "file_blocking_profiles" {
+  description = <<-EOF
+  List of the File Blocking profile objects. Each item supports following parameters:
+  - `name`: (required) Identifier of the File-blocking security profile.
+  - `description`: (optional) The description of the File-blocking profile.
+  - `rules`: (optional) List of objects following the rule specifications.
+    - `name`: (required) Rule name.
+    - `applications`: (optional) List of applications (default: `any`).
+    - `file_types`: (optional) File types included in the file-blocking rule.
+    - `direction`: (optional) Direction for the file-blocking rule to flow. Valid values are `both`, `upload`, or `download` (default: `both`).
+    - `action`: (optional) Action for the policy to take. Valid values are `alert`, `block`, or `continue` (default: `alert`).
+
+  Example:
+  ```
+  [
+    {
+      name = "Outbound-FB"
+      rules = [
+        {
+          name = "Alert-All"
+          applications = ["any"]
+          file_types = ["any"]
+          direction = "both"
+          action = "alert"
+        },
+        {
+          name = "Block"
+          applications = ["any"]
+          file_types = [
+            "7z",
+            "bat",
+            "chm",
+            "class",
+            "cpl",
+            "dll",
+            "hlp",
+            "hta",
+            "jar",
+            "ocx",
+            "pif",
+            "scr",
+            "torrent",
+            "vbe",
+            "wsf"
+          ]
+          direction = "both"
+          action = "block"
+        }
+      ]
+    }
+  ]
+  ```
+  EOF
+
+  default = {}
+  type = map(object({
+    description = optional(string)
+    rules = optional(list(object({
+      name         = string
+      applications = optional(list(string), ["any"])
+      file_types   = optional(list(string), ["any"])
+      direction    = optional(string, "both")
+      action       = optional(string, "alert")
+    })), [])
+  }))
+
+  validation {
+    condition = alltrue([
+      for profile in var.file_blocking_profiles : alltrue([
+        for rule in profile.rules : contains(["both", "upload", "download"], rule.direction)
+      ])
+    ])
+    error_message = "Valid 'direction' values are: 'both', 'upload', 'download'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.file_blocking_profiles : alltrue([
+        for rule in profile.rules : contains(["alert", "block", "continue"], rule.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'alert', 'block', 'continue'."
+  }
+}
+
+variable "vulnerability_protection_profiles" {
+  description = <<-EOF
+  List of the Vulnerability Protection profile objects. Each item supports following parameters:
+  - `name`: (required) Identifier of the Vulnerability security profile.
+  - `description`: (optional) The description of the vulnerability profile.
+  - `rules`: (optional) List of objects following the rule specifications.
+    - `name`: (required) Rule name.
+    - `threat_name`: (optional) Threat name.
+    - `cves`: (optional) List of CVEs (default: `any`).
+    - `host`: (optional) The host. Valid values are `any`, `client`, or `server` (default: `any`).
+    - `vendor_ids`: (optional) List of vendor IDs (default: `any`).
+    - `category`: (optional) Category for the file-blocking policy (default: `any`).
+    - `severities`: (optional) List of severities to include in policy. Valid values are `any`, `critical`, `high`, `medium`, `low`, or/and `informational` (default: `any`).
+    - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).
+    - `action`: (optional) Exception action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, `reset-both`, or `block-ip` (default: `default`).
+    - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.
+    - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.
+  - `exceptions`: (optional) List of objects following the exceptions specifications.
+    - `name`: (required) Threat name for the exception. You can use the `panos_predefined_threat` data source to discover the various names available to use.
+    - `packet_capture`: (optional) Packet capture setting. Valid values are `disable`, `single-packet`, or `extended-capture` (default: `disable`).
+    - `action`: (optional) Exception action. Valid values are `default`, `allow`, `alert`, `drop`, `reset-client`, `reset-server`, `reset-both`, or `block-ip` (default: `default`).
+    - `block_ip_track_by`: (required if `action` = `block-ip`) The track setting. Valid values are `source` or `source-and-destination`.
+    - `block_ip_duration`: (required if `action` = `block-ip`) The duration of the block. Valid values are integers.
+    - `exempt_ips`: (optional) List of exempt IPs.
+    - `time_interval`: (optional) Time interval integer.
+    - `time_threshold`: (optional) Time threshold integer.
+    - `time_track_by`: (optional) Time track by setting. Valid values are `source`, `destination`, or `source-and-destination`.
+
+  Example:
+  ```
+  [
+    {
+      name = "Outbound-VP"
+      rules = [
+        {
+          name = "Block-Critical-High-Medium"
+          action = "reset-both"
+          vendor_ids = ["any"]
+          severities = ["critical","high","medium"]
+          cves = ["any"]
+          threat_name = "any"
+          host = "any"
+          category = "any"
+          packet_capture = "single-packet"
+        },
+        {
+          name = "Default-Low-Info"
+          action = "default"
+          vendor_ids = ["any"]
+          severities = ["low","informational"]
+          cves = ["any"]
+          threat_name = "any"
+          host = "any"
+          category = "any"
+          packet_capture = "disable"
+        }
+      ]
+    }
+  ]
+  ```
+  EOF
+
+  default = {}
+  type = map(object({
+    description = optional(string)
+    rules = optional(list(object({
+      name              = string
+      threat_name       = optional(string, "any")
+      cves              = optional(set(string), ["any"])
+      host              = optional(string, "any")
+      vendor_ids        = optional(set(string), ["any"])
+      severities        = optional(list(string), ["any"])
+      category          = optional(string, "any")
+      action            = optional(string, "default")
+      block_ip_track_by = optional(string, "source")
+      block_ip_duration = optional(number)
+      packet_capture    = optional(string, "disable")
+    })), [])
+    exceptions = optional(list(object({
+      name              = string
+      packet_capture    = optional(string, "disable")
+      action            = optional(string, "default")
+      block_ip_track_by = optional(string, "source")
+      block_ip_duration = optional(number)
+      time_interval     = optional(number)
+      time_threshold    = optional(number)
+      time_track_by     = optional(string)
+      exempt_ips        = optional(list(string))
+    })), [])
+  }))
+
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for rule in profile.rules : contains(["any", "client", "server"], rule.host)
+      ])
+    ])
+    error_message = "Valid 'host' values are: 'any', 'client', 'server'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for rule in profile.rules : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both", "block-ip"], rule.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both', 'block-ip'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for rule in profile.rules : contains(["source", "source-and-destination"], rule.block_ip_track_by)
+      ])
+    ])
+    error_message = "Valid 'block_ip_track_by' values are: 'source', 'source-and-destination'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for rule in profile.rules : contains(["disable", "single-packet", "extended-capture"], rule.packet_capture)
+      ])
+    ])
+    error_message = "Valid 'packet_capture' values are: 'disable', 'single-packet', 'extended-capture'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for exception in profile.exceptions : contains(["disable", "single-packet", "extended-capture"], exception.packet_capture)
+      ])
+    ])
+    error_message = "Valid 'packet_capture' values are: 'disable', 'single-packet', 'extended-capture'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for exception in profile.exceptions : contains(["default", "allow", "alert", "drop", "reset-client", "reset-server", "reset-both", "block-ip"], exception.action)
+      ])
+    ])
+    error_message = "Valid actions are: 'default', 'allow', 'alert', 'drop', 'reset-client', 'reset-server', 'reset-both', 'block-ip'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for exception in profile.exceptions : contains(["source", "source-and-destination"], exception.block_ip_track_by)
+      ])
+    ])
+    error_message = "Valid 'block_ip_track_by' values are: 'source', 'source-and-destination'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.vulnerability_protection_profiles : alltrue([
+        for exception in profile.exceptions : contains(["source", "destination", "source-and-destination"], coalesce(exception.time_track_by, "source"))
+      ])
+    ])
+    error_message = "Valid 'time_track_by' values are: 'source', 'destination', 'source-and-destination'."
+  }
+}
+
+variable "wildfire_analysis_profiles" {
+  description = <<-EOF
+  List of the Wildfire Analysis profile objects. Each item supports following parameters:
+  - `name`: (required) Identifier of the Wildfire Analysis security profile.
+  - `device_group`: (optional) The device group location (default: `shared`).
+  - `description`: (optional) The description of the Wildfire Analysis profile.
+  - `rules`: (optional) List of objects following the rule specifications.
+    - `name`: (required) Rule name.
+    - `applications`: (optional) List of applications (default: `any`).
+    - `file_types`: (optional) List of file types (default: `any`).
+    - `direction`: (optional) Direction for the wildfire analysis policy. Valid values are `both`, `upload`, or `download` (default: `both`).
+    - `analysis`: (optional) Analysis setting. Valid values are `public-cloud` or `private-cloud` (default: `public-cloud`).
+
+  Example:
+  ```
+  [
+    {
+      name = "Outbound-WF"
+      rules = [
+        {
+          name = "Forward-All"
+          applications = ["any"]
+          file_types = ["any"]
+          direction = "both"
+          analysis = "public-cloud"
+        }
+      ]
+    }
+  ]
+  ```
+  EOF
+
+  default = {}
+  type = map(object({
+    description = optional(string)
+    rules = optional(list(object({
+      name         = string
+      applications = optional(list(string), ["any"])
+      file_types   = optional(list(string), ["any"])
+      direction    = optional(string, "both")
+      analysis     = optional(string, "public-cloud")
+    })), [])
+  }))
+
+  validation {
+    condition = alltrue([
+      for profile in var.wildfire_analysis_profiles : alltrue([
+        for rule in profile.rules : contains(["both", "upload", "download"], rule.direction)
+      ])
+    ])
+    error_message = "Valid 'direction' values are: 'both', 'upload', 'download'."
+  }
+  validation {
+    condition = alltrue([
+      for profile in var.wildfire_analysis_profiles : alltrue([
+        for rule in profile.rules : contains(["public-cloud", "private-cloud"], rule.analysis)
+      ])
+    ])
+    error_message = "Valid 'analysis' values are: 'public-cloud', 'private-cloud'."
+  }
+}

--- a/modules/security_profiles/versions.tf
+++ b/modules/security_profiles/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/security_rule_groups/README.md
+++ b/modules/security_rule_groups/README.md
@@ -1,0 +1,180 @@
+Palo Alto Networks PAN-OS security rule groups module
+---
+This Terraform module allows users to configure groups of rules within a security policy for a specific vsys or device group.
+Rules created using this module will not have impact on any existing rules, however it allows to position the groups against them using `position_keyword` and `position_reference` parameters to achieve a desired security posture.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "security_rule_groups" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/security_rule_groups"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group      = "test"
+  security_rule_groups = {
+    "allow_rule_group" = {
+      rulebase = "pre-rulebase"
+      rules = [
+        {
+          name = "Allow access to DNS Servers"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones          = ["Trust-L3"]
+          source_addresses      = ["RFC1918_Subnets"]
+          destination_zones     = ["Untrust-L3"]
+          destination_addresses = ["DNS-Servers"]
+          applications          = ["dns"]
+          services              = ["application-default"]
+          action                = "allow"
+          log_end               = "true"
+          virus                 = "default"
+          spyware               = "default"
+          vulnerability         = "default"
+        },
+        {
+          name             = "Allow access to RFC1918"
+          tags             = ["Managed by Terraform"]
+          source_zones     = ["Trust-L3"]
+          source_addresses = ["RFC1918_Subnets"]
+          destination_zones = [
+            "Trust-L3",
+            "Untrust-L3"
+          ]
+          destination_addresses = ["RFC1918_Subnets"]
+          services              = ["application-default"]
+          action                = "allow"
+          log_end               = "true"
+          virus                 = "default"
+          spyware               = "default"
+          vulnerability         = "default"
+        },
+        {
+          name = "Disabled - temporary access to Srv10 and Srv11"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones = ["Trust-L3"]
+          source_addresses = [
+            "Server10",
+            "Server11"
+          ]
+          destination_zones     = ["Untrust-L3"]
+          destination_addresses = ["123.123.123.123/32"]
+          services              = ["SSH-8022"]
+          action                = "allow"
+          log_end               = "true"
+          disabled              = "true"
+          virus                 = "default"
+          spyware               = "default"
+          vulnerability         = "default"
+          url_filtering         = "default"
+          file_blocking         = "basic file blocking"
+          wildfire_analysis     = "default"
+        },
+        {
+          name = "Allow access to SSH Servers"
+          tags = [
+            "Inbound",
+            "Managed by Terraform"
+          ]
+          source_zones          = ["Untrust-L3"]
+          negate_source         = "false"
+          destination_zones     = ["Trust-L3"]
+          destination_addresses = ["SSH-Servers"]
+          negate_destination    = "false"
+          applications          = ["ssh"]
+          services              = ["application-default"]
+          action                = "allow"
+          log_end               = "true"
+        }
+      ]
+    }
+    "block_rule_group" = {
+      position_keyword = "bottom"
+      rulebase         = "pre-rulebase"
+      rules = [
+        {
+          name = "Block Some Traffic"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones     = ["Trust-L3"]
+          source_addresses = ["10.0.0.100/32"]
+          action           = "deny"
+          log_end          = "true"
+        }
+      ]
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_security_rule_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/security_rule_group) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if `mode` is panorama, this defines the Device Group for the deployment | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if `mode` is ngfw, this defines the vsys for the deployment | `string` | `"vsys1"` | no |
+| <a name="input_security_rule_groups"></a> [security\_rule\_groups](#input\_security\_rule\_groups) | Map with groups of security rules to apply. Each item supports following parameters:<br>- `rulebase`: (optional) The rulebase for the Security Policy. Valid values are `pre-rulebase` and `post-rulebase` (default: `pre-rulebase`).<br>- `position_keyword`: (optional) A positioning keyword for this group. Valid values are `before`, `directly before`, `after`, `directly after`, `top`, `bottom`, or left empty to have no particular placement (default: empty). This parameter works in combination with the `position_reference` parameter.<br>- `position_reference`: (optional) Required if `position_keyword` is one of the "above" or "below" variants, this is the name of a non-group rule to use as a reference to place this group.<br>- `rules`: (optional) List of security rule definitions. The order of the rules will match how they appear in the terraform plan file.<br>  - `name`: (required) The security rule's name.<br>  - `description`: (optional) The description of the security rule.<br>  - `type`: (optional) Rule type. Valid values are `universal`, `interzone`, or `intrazone` (default: `universal`).<br>  - `tags`: (optional) List of administrative tags.<br>  - `source_addresses`: (optional) List of source addresses (default: `any`).<br>  - `source_zones`: (optional) List of source zones (default: `any`).<br>  - `source_users`: (optional) List of source users (default: `any`).<br>  - `source_device`: (optional) List of source devices (default: `any`).<br>  - `negate_source`: (optional) Boolean designating if the source should be negated (default: `false`).<br>  - `hip_profiles`: (optional) List of HIP profiles (default: `any`).<br>  - `destination_zones`: (optional) List of destination zones (default: `any`).<br>  - `destination_addresses`: (optional) List of destination addresses (default: `any`).<br>  - `destination_device`: (optional) List of destination devices (default: `any`).<br>  - `negate_destination`: (optional) Boolean designating if the destination should be negated (default: `false`).<br>  - `applications`: (optional) List of applications (default: `any`).<br>  - `services`: (optional) List of services (default: `application-default`).<br>  - `categories`: (optional) List of categories (default: `any`).<br>  - `action`: (optional) Action for the matched traffic. Valid values are `allow`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `allow`).<br>  - `log_setting`: (optional) Log forwarding profile.<br>  - `log_start`: (optional) Boolean designating if log the start of the traffic flow (default: `false`).<br>  - `log_end`: (optional) Boolean designating if log the end of the traffic flow (default: `true`).<br>  - `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).<br>  - `schedule`: (optional) The security rule schedule.<br>  - `icmp_unreachable`: (optional) Boolean enabling ICMP unreachable (default: `false`).<br>  - `disable_server_response_inspection`: (optional) Boolean disabling server response inspection (default: `false`).<br>  - `group`: (optional) Profile setting: `Group` - The group profile name.<br>  - `virus`: (optional) Profile setting: `Profiles` - Input the desired antivirus profile name.<br>  - `spyware`: (optional) Profile setting: `Profiles` - Input the desired anti-spyware profile name.<br>  - `vulnerability`: (optional) Profile setting: `Profiles` - Input the desired vulnerability profile name.<br>  - `url_filtering`: (optional) Profile setting: `Profiles` - Input the desired URL filtering profile name.<br>  - `file_blocking`: (optional) Profile setting: `Profiles` - Input the desired File-Blocking profile name.<br>  - `wildfire_analysis`: (optional) Profile setting: `Profiles` - Input the desired Wildfire Analysis profile name.<br>  - `data_filtering`: (optional) Profile setting: `Profiles` - Input the desired Data Filtering profile name.<br>  - `audit_comment`: (optional) Comment to apply when the rule is created/updated.<br>  - `group_tag`: (optional) Group tag.<br>  - `negate_target`: (optional, Panorama only) Instead of applying the rule for the given serial numbers, apply it to everything except them.<br>  - `target`: (optional, Panorama only) A target definition,if there are no target sections, then the rule will apply to every vsys of every device in the device group.<br><br>Example:<pre>{<br>  "allow_rule_group" = {<br>    rulebase = "pre-rulebase"<br>    rules = [<br>      {<br>        name = "Allow access to DNS Servers"<br>        tags = [<br>          "Outbound",<br>          "Managed by Terraform"<br>        ]<br>        source_zones                       = ["Trust-L3"]<br>        source_addresses                   = ["RFC1918_Subnets"]<br>        destination_zones                  = ["Untrust-L3"]<br>        destination_addresses              = ["DNS-Servers"]<br>        applications                       = ["dns"]<br>        services                           = ["application-default"]<br>        action                             = "allow"<br>        log_end                            = "true"<br>      },<br>      {<br>        name             = "Allow access to RFC1918"<br>        tags             = ["Managed by Terraform"]<br>        source_zones     = ["Trust-L3"]<br>        source_addresses = ["RFC1918_Subnets"]<br>        destination_zones = [<br>          "Trust-L3",<br>          "Untrust-L3"<br>        ]<br>        destination_addresses              = ["RFC1918_Subnets"]<br>        services                           = ["application-default"]<br>        action                             = "allow"<br>        log_end                            = "true"<br>        virus                              = "default"<br>        spyware                            = "default"<br>        vulnerability                      = "default"<br>      }<br>    ]<br>  }<br>  "block_rule_group" = {<br>    position_keyword = "bottom"<br>    rulebase         = "pre-rulebase"<br>    rules = [<br>      {<br>        name = "Block Some Traffic"<br>        tags = [<br>          "Outbound",<br>          "Managed by Terraform"<br>        ]<br>        source_zones                       = ["Trust-L3"]<br>        source_addresses                   = ["10.0.0.100/32"]<br>        action                             = "deny"<br>        log_end                            = "true"<br>      }<br>    ]<br>  }<br>}</pre> | <pre>map(object({<br>    rulebase           = optional(string, "pre-rulebase")<br>    position_keyword   = optional(string)<br>    position_reference = optional(string)<br>    rules = list(object({<br>      name                               = string<br>      type                               = optional(string, "universal")<br>      description                        = optional(string)<br>      tags                               = optional(list(string))<br>      source_zones                       = optional(list(string), ["any"])<br>      source_addresses                   = optional(list(string), ["any"])<br>      source_users                       = optional(list(string), ["any"])<br>      source_devices                     = optional(list(string), ["any"])<br>      negate_source                      = optional(string, false)<br>      hip_profiles                       = optional(list(string), ["any"])<br>      destination_zones                  = optional(list(string), ["any"])<br>      destination_addresses              = optional(list(string), ["any"])<br>      destination_devices                = optional(list(string), ["any"])<br>      negate_destination                 = optional(string, false)<br>      applications                       = optional(list(string), ["any"])<br>      services                           = optional(list(string), ["application-default"])<br>      categories                         = optional(list(string), ["any"])<br>      action                             = optional(string, "allow")<br>      log_setting                        = optional(string)<br>      log_start                          = optional(string, false)<br>      log_end                            = optional(string, true)<br>      disabled                           = optional(string, false)<br>      schedule                           = optional(string)<br>      icmp_unreachable                   = optional(string)<br>      disable_server_response_inspection = optional(bool, false)<br>      group                              = optional(string)<br>      virus                              = optional(string)<br>      spyware                            = optional(string)<br>      vulnerability                      = optional(string)<br>      url_filtering                      = optional(string)<br>      file_blocking                      = optional(string)<br>      wildfire_analysis                  = optional(string)<br>      data_filtering                     = optional(string)<br>      audit_comment                      = optional(string)<br>      group_tag                          = optional(string)<br>      negate_target                      = optional(bool, false)<br>      target = optional(list(object({<br>        serial    = string<br>        vsys_list = optional(list(string))<br>      })), null)<br>    }))<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_security_rule_groups"></a> [security\_rule\_groups](#output\_security\_rule\_groups) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/security_rule_groups/main.tf
+++ b/modules/security_rule_groups/main.tf
@@ -1,0 +1,72 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_security_rule_group" "this" {
+  for_each = var.security_rule_groups
+
+  device_group = local.mode_map[var.mode] == 0 ? var.device_group : null
+  rulebase     = local.mode_map[var.mode] == 0 ? each.value.rulebase : null
+  vsys         = local.mode_map[var.mode] == 1 ? var.vsys : null
+
+  position_keyword   = each.value.position_keyword
+  position_reference = each.value.position_reference
+
+  dynamic "rule" {
+    for_each = each.value.rules
+    content {
+      applications                       = rule.value.applications
+      categories                         = rule.value.categories
+      destination_addresses              = rule.value.destination_addresses
+      destination_devices                = rule.value.destination_devices
+      destination_zones                  = rule.value.destination_zones
+      name                               = rule.value.name
+      services                           = rule.value.services
+      source_addresses                   = rule.value.source_addresses
+      source_devices                     = rule.value.source_devices
+      source_users                       = rule.value.source_users
+      source_zones                       = rule.value.source_zones
+      hip_profiles                       = rule.value.hip_profiles
+      description                        = rule.value.description
+      tags                               = rule.value.tags
+      type                               = rule.value.type
+      negate_source                      = rule.value.negate_source
+      negate_destination                 = rule.value.negate_destination
+      action                             = rule.value.action
+      log_setting                        = rule.value.log_setting
+      log_start                          = rule.value.log_start
+      log_end                            = rule.value.log_end
+      disabled                           = rule.value.disabled
+      schedule                           = rule.value.schedule
+      icmp_unreachable                   = rule.value.icmp_unreachable
+      disable_server_response_inspection = rule.value.disable_server_response_inspection
+      group                              = rule.value.group
+      virus                              = rule.value.virus
+      spyware                            = rule.value.spyware
+      vulnerability                      = rule.value.vulnerability
+      url_filtering                      = rule.value.url_filtering
+      file_blocking                      = rule.value.file_blocking
+      wildfire_analysis                  = rule.value.wildfire_analysis
+      data_filtering                     = rule.value.data_filtering
+      audit_comment                      = rule.value.audit_comment
+      group_tag                          = rule.value.group_tag
+      negate_target                      = rule.value.negate_target
+
+      dynamic "target" {
+        for_each = try(rule.value.target, null) != null ? { for t in rule.value.target : t.serial => t } : {}
+        content {
+          serial    = target.value.serial
+          vsys_list = target.value.vsys_list
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/security_rule_groups/main_test.go
+++ b/modules/security_rule_groups/main_test.go
@@ -1,0 +1,11 @@
+package security_rule_groups
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/security_rule_groups/outputs.tf
+++ b/modules/security_rule_groups/outputs.tf
@@ -1,0 +1,3 @@
+output "security_rule_groups" {
+  value = panos_security_rule_group.this
+}

--- a/modules/security_rule_groups/variables.tf
+++ b/modules/security_rule_groups/variables.tf
@@ -1,0 +1,196 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_group" {
+  description = "Used if `mode` is panorama, this defines the Device Group for the deployment"
+  default     = "shared"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if `mode` is ngfw, this defines the vsys for the deployment"
+  default     = "vsys1"
+  type        = string
+}
+
+#policy
+variable "security_rule_groups" {
+  description = <<-EOF
+  Map with groups of security rules to apply. Each item supports following parameters:
+  - `rulebase`: (optional) The rulebase for the Security Policy. Valid values are `pre-rulebase` and `post-rulebase` (default: `pre-rulebase`).
+  - `position_keyword`: (optional) A positioning keyword for this group. Valid values are `before`, `directly before`, `after`, `directly after`, `top`, `bottom`, or left empty to have no particular placement (default: empty). This parameter works in combination with the `position_reference` parameter.
+  - `position_reference`: (optional) Required if `position_keyword` is one of the "above" or "below" variants, this is the name of a non-group rule to use as a reference to place this group.
+  - `rules`: (optional) List of security rule definitions. The order of the rules will match how they appear in the terraform plan file.
+    - `name`: (required) The security rule's name.
+    - `description`: (optional) The description of the security rule.
+    - `type`: (optional) Rule type. Valid values are `universal`, `interzone`, or `intrazone` (default: `universal`).
+    - `tags`: (optional) List of administrative tags.
+    - `source_addresses`: (optional) List of source addresses (default: `any`).
+    - `source_zones`: (optional) List of source zones (default: `any`).
+    - `source_users`: (optional) List of source users (default: `any`).
+    - `source_device`: (optional) List of source devices (default: `any`).
+    - `negate_source`: (optional) Boolean designating if the source should be negated (default: `false`).
+    - `hip_profiles`: (optional) List of HIP profiles (default: `any`).
+    - `destination_zones`: (optional) List of destination zones (default: `any`).
+    - `destination_addresses`: (optional) List of destination addresses (default: `any`).
+    - `destination_device`: (optional) List of destination devices (default: `any`).
+    - `negate_destination`: (optional) Boolean designating if the destination should be negated (default: `false`).
+    - `applications`: (optional) List of applications (default: `any`).
+    - `services`: (optional) List of services (default: `application-default`).
+    - `categories`: (optional) List of categories (default: `any`).
+    - `action`: (optional) Action for the matched traffic. Valid values are `allow`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `allow`).
+    - `log_setting`: (optional) Log forwarding profile.
+    - `log_start`: (optional) Boolean designating if log the start of the traffic flow (default: `false`).
+    - `log_end`: (optional) Boolean designating if log the end of the traffic flow (default: `true`).
+    - `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).
+    - `schedule`: (optional) The security rule schedule.
+    - `icmp_unreachable`: (optional) Boolean enabling ICMP unreachable (default: `false`).
+    - `disable_server_response_inspection`: (optional) Boolean disabling server response inspection (default: `false`).
+    - `group`: (optional) Profile setting: `Group` - The group profile name.
+    - `virus`: (optional) Profile setting: `Profiles` - Input the desired antivirus profile name.
+    - `spyware`: (optional) Profile setting: `Profiles` - Input the desired anti-spyware profile name.
+    - `vulnerability`: (optional) Profile setting: `Profiles` - Input the desired vulnerability profile name.
+    - `url_filtering`: (optional) Profile setting: `Profiles` - Input the desired URL filtering profile name.
+    - `file_blocking`: (optional) Profile setting: `Profiles` - Input the desired File-Blocking profile name.
+    - `wildfire_analysis`: (optional) Profile setting: `Profiles` - Input the desired Wildfire Analysis profile name.
+    - `data_filtering`: (optional) Profile setting: `Profiles` - Input the desired Data Filtering profile name.
+    - `audit_comment`: (optional) Comment to apply when the rule is created/updated.
+    - `group_tag`: (optional) Group tag.
+    - `negate_target`: (optional, Panorama only) Instead of applying the rule for the given serial numbers, apply it to everything except them.
+    - `target`: (optional, Panorama only) A target definition,if there are no target sections, then the rule will apply to every vsys of every device in the device group.
+
+  Example:
+  ```
+  {
+    "allow_rule_group" = {
+      rulebase = "pre-rulebase"
+      rules = [
+        {
+          name = "Allow access to DNS Servers"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones                       = ["Trust-L3"]
+          source_addresses                   = ["RFC1918_Subnets"]
+          destination_zones                  = ["Untrust-L3"]
+          destination_addresses              = ["DNS-Servers"]
+          applications                       = ["dns"]
+          services                           = ["application-default"]
+          action                             = "allow"
+          log_end                            = "true"
+        },
+        {
+          name             = "Allow access to RFC1918"
+          tags             = ["Managed by Terraform"]
+          source_zones     = ["Trust-L3"]
+          source_addresses = ["RFC1918_Subnets"]
+          destination_zones = [
+            "Trust-L3",
+            "Untrust-L3"
+          ]
+          destination_addresses              = ["RFC1918_Subnets"]
+          services                           = ["application-default"]
+          action                             = "allow"
+          log_end                            = "true"
+          virus                              = "default"
+          spyware                            = "default"
+          vulnerability                      = "default"
+        }
+      ]
+    }
+    "block_rule_group" = {
+      position_keyword = "bottom"
+      rulebase         = "pre-rulebase"
+      rules = [
+        {
+          name = "Block Some Traffic"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones                       = ["Trust-L3"]
+          source_addresses                   = ["10.0.0.100/32"]
+          action                             = "deny"
+          log_end                            = "true"
+        }
+      ]
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    rulebase           = optional(string, "pre-rulebase")
+    position_keyword   = optional(string)
+    position_reference = optional(string)
+    rules = list(object({
+      name                               = string
+      type                               = optional(string, "universal")
+      description                        = optional(string)
+      tags                               = optional(list(string))
+      source_zones                       = optional(list(string), ["any"])
+      source_addresses                   = optional(list(string), ["any"])
+      source_users                       = optional(list(string), ["any"])
+      source_devices                     = optional(list(string), ["any"])
+      negate_source                      = optional(string, false)
+      hip_profiles                       = optional(list(string), ["any"])
+      destination_zones                  = optional(list(string), ["any"])
+      destination_addresses              = optional(list(string), ["any"])
+      destination_devices                = optional(list(string), ["any"])
+      negate_destination                 = optional(string, false)
+      applications                       = optional(list(string), ["any"])
+      services                           = optional(list(string), ["application-default"])
+      categories                         = optional(list(string), ["any"])
+      action                             = optional(string, "allow")
+      log_setting                        = optional(string)
+      log_start                          = optional(string, false)
+      log_end                            = optional(string, true)
+      disabled                           = optional(string, false)
+      schedule                           = optional(string)
+      icmp_unreachable                   = optional(string)
+      disable_server_response_inspection = optional(bool, false)
+      group                              = optional(string)
+      virus                              = optional(string)
+      spyware                            = optional(string)
+      vulnerability                      = optional(string)
+      url_filtering                      = optional(string)
+      file_blocking                      = optional(string)
+      wildfire_analysis                  = optional(string)
+      data_filtering                     = optional(string)
+      audit_comment                      = optional(string)
+      group_tag                          = optional(string)
+      negate_target                      = optional(bool, false)
+      target = optional(list(object({
+        serial    = string
+        vsys_list = optional(list(string))
+      })), null)
+    }))
+  }))
+  validation {
+    condition = alltrue([
+      for rule_group in var.security_rule_groups : alltrue([
+        for rule in rule_group.rules :
+        contains(["universal", "interzone", "intrazone"], coalesce(rule.type, "universal"))
+      ])
+    ])
+    error_message = "Valid types of type are `universal`, `interzone`, `intrazone`"
+  }
+  validation {
+    condition = alltrue([
+      for rule_group in var.security_rule_groups : alltrue([
+        for rule in rule_group.rules :
+        contains([
+          "allow", "deny", "drop", "reset-client", "reset-server", "reset-both"
+        ], coalesce(rule.action, "allow"))
+      ])
+    ])
+    error_message = "Valid types of action are `allow`, `deny`, `drop`, `reset-client`, `reset-server`, `reset-both`"
+  }
+}

--- a/modules/security_rule_groups/versions.tf
+++ b/modules/security_rule_groups/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -1,0 +1,124 @@
+Palo Alto Networks PAN-OS Services Module
+---
+This Terraform module allows users to configure services.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "services" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/services"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group = "test"
+  services     = {
+    SomeWeb = {
+      protocol         = "tcp"
+      destination_port = "80,443"
+      description      = "Some web services"
+    }
+    SomeFTP = {
+      protocol         = "tcp"
+      destination_port = "21"
+      description      = "Some FTP services"
+    }
+    SomeSSH = {
+      protocol         = "tcp"
+      destination_port = "21"
+      description      = "Some SSH services"
+    }
+    SSH-8022 = {
+      protocol         = "tcp"
+      destination_port = "8022"
+      description      = "SSH not-default port"
+    }
+    Web-8080 = {
+      protocol         = "tcp"
+      destination_port = "8080"
+      description      = "HTTP not-default port"
+    }
+    tcp_4450 = {
+      protocol         = "tcp"
+      destination_port = "4450"
+      description      = "Custom ports for PSN Services"
+    }
+    tcp_4457-4458 = {
+      protocol         = "tcp"
+      destination_port = "4457-4458"
+      description      = "Custom ports for PSN Services"
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_panorama_service_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_service_group) | resource |
+| [panos_panorama_service_object.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_service_object) | resource |
+| [panos_service_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/service_group) | resource |
+| [panos_service_object.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/service_object) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if _mode_ is panorama, this defines the Device Group for the deployment | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if _mode_ is ngfw, this defines the vsys for the deployment | `string` | `"vsys1"` | no |
+| <a name="input_services"></a> [services](#input\_services) | Map of the service objects, where key is the service object's name:<br>- `description`: (optional) The description of the service object.<br>- `protocol`: (required) The service's protocol. Valid values are `tcp`, `udp`, or `sctp` (only for PAN-OS 8.1+).<br>- `source_port`: (optional) The source port. This can be a single port number, range (1-65535), or comma separated (80,8080,443).<br>- `destination_port`: (required) The destination port. This can be a single port number, range (1-65535), or comma separated (80,8080,443).<br>- `tags`: (optional) List of administrative tags.<br>- `override_session_timeout`: (optional) Boolean to override the default application timeouts (default: `false`). Only available for PAN-OS 8.1+.<br>- `override_timeout`: (optional) Integer for the overridden timeout if TCP protocol selected. Only available for PAN-OS 8.1+.<br>- `override_half_closed_timeout`: (optional) Integer for the overridden half closed timeout if TCP protocol selected. Only available for PAN-OS 8.1+.<br>- `override_time_wait_timeout`: (optional) Integer for the overridden wait time if TCP protocol selected. Only available for PAN-OS 8.1+.<br><br>Example:<pre>services = {<br>  WEB-APP = {<br>    protocol         = "tcp"<br>    destination_port = "80,443"<br>    description      = "Some web services"<br>  }<br>  SSH-8022 = {<br>    protocol         = "tcp"<br>    destination_port = "8022"<br>    description      = "SSH not-default port"<br>  }<br>  TCP-4457-4458 = {<br>    protocol         = "tcp"<br>    destination_port = "4457-4458"<br>    description      = "Custom port range"<br>  }<br>}</pre> | <pre>map(object({<br>    description                  = optional(string)<br>    protocol                     = string<br>    source_port                  = optional(string)<br>    destination_port             = string<br>    tags                         = optional(list(string))<br>    override_session_timeout     = optional(bool)<br>    override_timeout             = optional(number)<br>    override_half_closed_timeout = optional(number)<br>    override_time_wait_timeout   = optional(number)<br>  }))</pre> | `{}` | no |
+| <a name="input_service_groups"></a> [service\_groups](#input\_service\_groups) | Map of the service groups, where key is the service group's name:<br>- `members`: (required) The service objects to include in this service group.<br>- `tags`: (optional) List of administrative tags.<br><br>Example:<pre>service_groups = {<br>  "Customer Group" = {<br>    members = ["WEB-APP", "TCP-4457-4458"]<br>  }<br>}</pre> | <pre>map(object({<br>    members = list(string)<br>    tags    = optional(list(string))<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panorama_service_groups"></a> [panorama\_service\_groups](#output\_panorama\_service\_groups) | n/a |
+| <a name="output_service_groups"></a> [service\_groups](#output\_service\_groups) | n/a |
+| <a name="output_panorama_services"></a> [panorama\_services](#output\_panorama\_services) | n/a |
+| <a name="output_services"></a> [services](#output\_services) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/services/main.tf
+++ b/modules/services/main.tf
@@ -1,0 +1,88 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_panorama_service_object" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.services : {}
+
+  device_group = var.device_group
+
+  destination_port = each.value.destination_port
+  name             = each.key
+  protocol         = each.value.protocol
+
+  description                  = try(each.value.description, null)
+  source_port                  = try(each.value.source_port, null)
+  tags                         = try(each.value.tags, null)
+  override_session_timeout     = try(each.value.override_session_timeout, false)
+  override_timeout             = try(each.value.override_timeout, null)
+  override_half_closed_timeout = try(each.value.override_half_closed_timeout, null)
+  override_time_wait_timeout   = try(each.value.override_time_wait_timeout, null)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_service_object" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.services : {}
+
+  vsys = var.vsys
+
+  destination_port = each.value.destination_port
+  name             = each.key
+  protocol         = each.value.protocol
+
+  description                  = try(each.value.description, null)
+  source_port                  = try(each.value.source_port, null)
+  tags                         = try(each.value.tags, null)
+  override_session_timeout     = try(each.value.override_session_timeout, false)
+  override_timeout             = try(each.value.override_timeout, null)
+  override_half_closed_timeout = try(each.value.override_half_closed_timeout, null)
+  override_time_wait_timeout   = try(each.value.override_time_wait_timeout, null)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_service_group" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.service_groups : {}
+
+  device_group = var.device_group
+
+  name     = each.key
+  services = try(each.value.members, [])
+  tags     = try(each.value.tags, null)
+
+  depends_on = [
+    panos_panorama_service_object.this
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+
+resource "panos_service_group" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.service_groups : {}
+
+  vsys = var.vsys
+
+  name     = each.key
+  services = try(each.value.members, [])
+  tags     = try(each.value.tags, null)
+
+  depends_on = [
+    panos_service_object.this
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/services/main_test.go
+++ b/modules/services/main_test.go
@@ -1,0 +1,11 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/services/outputs.tf
+++ b/modules/services/outputs.tf
@@ -1,0 +1,15 @@
+output "panorama_service_groups" {
+  value = panos_panorama_service_group.this
+}
+
+output "service_groups" {
+  value = panos_service_group.this
+}
+
+output "panorama_services" {
+  value = panos_panorama_service_object.this
+}
+
+output "services" {
+  value = panos_service_object.this
+}

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -1,0 +1,94 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_group" {
+  description = "Used if _mode_ is panorama, this defines the Device Group for the deployment"
+  default     = "shared"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if _mode_ is ngfw, this defines the vsys for the deployment"
+  default     = "vsys1"
+  type        = string
+}
+
+variable "services" {
+  description = <<-EOF
+  Map of the service objects, where key is the service object's name:
+  - `description`: (optional) The description of the service object.
+  - `protocol`: (required) The service's protocol. Valid values are `tcp`, `udp`, or `sctp` (only for PAN-OS 8.1+).
+  - `source_port`: (optional) The source port. This can be a single port number, range (1-65535), or comma separated (80,8080,443).
+  - `destination_port`: (required) The destination port. This can be a single port number, range (1-65535), or comma separated (80,8080,443).
+  - `tags`: (optional) List of administrative tags.
+  - `override_session_timeout`: (optional) Boolean to override the default application timeouts (default: `false`). Only available for PAN-OS 8.1+.
+  - `override_timeout`: (optional) Integer for the overridden timeout if TCP protocol selected. Only available for PAN-OS 8.1+.
+  - `override_half_closed_timeout`: (optional) Integer for the overridden half closed timeout if TCP protocol selected. Only available for PAN-OS 8.1+.
+  - `override_time_wait_timeout`: (optional) Integer for the overridden wait time if TCP protocol selected. Only available for PAN-OS 8.1+.
+
+  Example:
+  ```
+  services = {
+    WEB-APP = {
+      protocol         = "tcp"
+      destination_port = "80,443"
+      description      = "Some web services"
+    }
+    SSH-8022 = {
+      protocol         = "tcp"
+      destination_port = "8022"
+      description      = "SSH not-default port"
+    }
+    TCP-4457-4458 = {
+      protocol         = "tcp"
+      destination_port = "4457-4458"
+      description      = "Custom port range"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    description                  = optional(string)
+    protocol                     = string
+    source_port                  = optional(string)
+    destination_port             = string
+    tags                         = optional(list(string))
+    override_session_timeout     = optional(bool)
+    override_timeout             = optional(number)
+    override_half_closed_timeout = optional(number)
+    override_time_wait_timeout   = optional(number)
+  }))
+  validation {
+    condition     = alltrue([for service in var.services : contains(["tcp", "udp", "sctp"], service.protocol)])
+    error_message = "Valid values for the protocol are `tcp`, `udp`, or `sctp`"
+  }
+}
+
+variable "service_groups" {
+  description = <<-EOF
+  Map of the service groups, where key is the service group's name:
+  - `members`: (required) The service objects to include in this service group.
+  - `tags`: (optional) List of administrative tags.
+
+  Example:
+  ```
+  service_groups = {
+    "Customer Group" = {
+      members = ["WEB-APP", "TCP-4457-4458"]
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    members = list(string)
+    tags    = optional(list(string))
+  }))
+}

--- a/modules/services/versions.tf
+++ b/modules/services/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/static_routes/README.md
+++ b/modules/static_routes/README.md
@@ -1,0 +1,110 @@
+Palo Alto Networks PAN-OS Static Routes Module
+---
+This Terraform module allows users to configure static routes.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "static_routes" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/static_routes"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  template = "test"
+
+  static_routes = {
+    "vr_default_unicast_0.0.0.0" = {
+      virtual_router = "vr"
+      route_table    = "unicast"
+      destination    = "0.0.0.0/0"
+      interface      = "ethernet1/1"
+      type           = "ip-address"
+      next_hop       = "10.1.1.1"
+      metric         = 10
+    }
+    "vr_internal_unicast_10.10.10.0" = {
+      virtual_router = "internal"
+      route_table    = "unicast"
+      destination    = "10.10.10.0/24"
+      interface      = "tunnel.42"
+      type           = ""
+    }
+    "vr_external_unicast_0.0.0.0" = {
+      virtual_router = "external"
+      route_table    = "unicast"
+      destination    = "0.0.0.0/0"
+      interface      = "ethernet1/2"
+      type           = "ip-address"
+      next_hop       = "10.1.2.1"
+      metric         = 10
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_panorama_static_route_ipv4.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_static_route_ipv4) | resource |
+| [panos_static_route_ipv4.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/static_route_ipv4) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_template"></a> [template](#input\_template) | The template name. | `string` | `"default"` | no |
+| <a name="input_template_stack"></a> [template\_stack](#input\_template\_stack) | The template stack name. | `string` | `""` | no |
+| <a name="input_static_routes"></a> [static\_routes](#input\_static\_routes) | Map of the static routes, where key is the unique name e.g. build in format "{virtual\_router}\_{route\_table}":<br>- `virtual_router` - (Required) The virtual router to add the static route to.<br>- `route_table` - (Optional) Target routing table to install the route. Valid values are unicast (the default), no install, multicast, or both.<br>- `destination` - (Required) Destination IP address / prefix.<br>- `interface` - (Optional) Interface to use.<br>- `type` - (Optional) The next hop type. Valid values are ip-address (the default), discard, next-vr, or an empty string for None.<br>- `next_hop` - (Optional) The value for the type setting.<br>- `admin_distance` - (Optional) The admin distance.<br>- `metric` - (Optional, int) Metric value / path cost (default: 10).<br>- `bfd_profile` - (Optional, PAN-OS 7.1+) BFD configuration.<br><br>Example:<pre>{<br>  "vr_default_unicast_0.0.0.0" = {<br>    virtual_router = "default"<br>    route_table    = "unicast"<br>    destination    = "0.0.0.0/0"<br>    interface      = "ethernet1/1"<br>    type           = "ip-address"<br>    next_hop       = "10.1.1.1"<br>    admin_distance = null<br>    metric         = 10<br>  }<br>}</pre> | <pre>map(object({<br>    virtual_router = string<br>    route_table    = optional(string, "unicast")<br>    destination    = string<br>    interface      = optional(string)<br>    type           = optional(string, "ip-address")<br>    next_hop       = optional(string)<br>    admin_distance = optional(number)<br>    metric         = optional(number, 10)<br>    bfd_profile    = optional(string)<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panorama_static_routes_ipv4"></a> [panorama\_static\_routes\_ipv4](#output\_panorama\_static\_routes\_ipv4) | n/a |
+| <a name="output_static_routes_ipv4"></a> [static\_routes\_ipv4](#output\_static\_routes\_ipv4) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/static_routes/main.tf
+++ b/modules/static_routes/main.tf
@@ -1,0 +1,48 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_panorama_static_route_ipv4" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.static_routes : {}
+
+  template       = var.template_stack == "" ? var.template : null
+  template_stack = var.template_stack == "" ? null : var.template_stack
+
+  name           = each.key
+  virtual_router = each.value.virtual_router
+  route_table    = each.value.route_table
+  destination    = each.value.destination
+  interface      = each.value.interface
+  type           = each.value.type
+  next_hop       = each.value.next_hop
+  admin_distance = each.value.admin_distance
+  metric         = each.value.metric
+  bfd_profile    = each.value.bfd_profile
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_static_route_ipv4" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.static_routes : {}
+
+  name           = each.key
+  virtual_router = each.value.virtual_router
+  route_table    = each.value.route_table
+  destination    = each.value.destination
+  interface      = each.value.interface
+  type           = each.value.type
+  next_hop       = each.value.next_hop
+  admin_distance = each.value.admin_distance
+  metric         = each.value.metric
+  bfd_profile    = each.value.bfd_profile
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/static_routes/main_test.go
+++ b/modules/static_routes/main_test.go
@@ -1,0 +1,11 @@
+package static_routes
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/static_routes/outputs.tf
+++ b/modules/static_routes/outputs.tf
@@ -1,0 +1,7 @@
+output "panorama_static_routes_ipv4" {
+  value = panos_panorama_static_route_ipv4.this
+}
+
+output "static_routes_ipv4" {
+  value = panos_static_route_ipv4.this
+}

--- a/modules/static_routes/variables.tf
+++ b/modules/static_routes/variables.tf
@@ -1,0 +1,71 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "template" {
+  description = "The template name."
+  default     = "default"
+  type        = string
+}
+
+variable "template_stack" {
+  description = "The template stack name."
+  default     = ""
+  type        = string
+}
+
+variable "static_routes" {
+  description = <<-EOF
+  Map of the static routes, where key is the unique name e.g. build in format "{virtual_router}_{route_table}":
+  - `virtual_router` - (Required) The virtual router to add the static route to.
+  - `route_table` - (Optional) Target routing table to install the route. Valid values are unicast (the default), no install, multicast, or both.
+  - `destination` - (Required) Destination IP address / prefix.
+  - `interface` - (Optional) Interface to use.
+  - `type` - (Optional) The next hop type. Valid values are ip-address (the default), discard, next-vr, or an empty string for None.
+  - `next_hop` - (Optional) The value for the type setting.
+  - `admin_distance` - (Optional) The admin distance.
+  - `metric` - (Optional, int) Metric value / path cost (default: 10).
+  - `bfd_profile` - (Optional, PAN-OS 7.1+) BFD configuration.
+
+  Example:
+  ```
+  {
+    "vr_default_unicast_0.0.0.0" = {
+      virtual_router = "default"
+      route_table    = "unicast"
+      destination    = "0.0.0.0/0"
+      interface      = "ethernet1/1"
+      type           = "ip-address"
+      next_hop       = "10.1.1.1"
+      admin_distance = null
+      metric         = 10
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    virtual_router = string
+    route_table    = optional(string, "unicast")
+    destination    = string
+    interface      = optional(string)
+    type           = optional(string, "ip-address")
+    next_hop       = optional(string)
+    admin_distance = optional(number)
+    metric         = optional(number, 10)
+    bfd_profile    = optional(string)
+  }))
+  validation {
+    condition     = alltrue(flatten([for static_route in var.static_routes : contains(["unicast", "no install", "multicast", "both"], static_route.route_table)]))
+    error_message = "Valid values of route tables are `unicast` (the default), `no install`, `multicast`, or `both`"
+  }
+  validation {
+    condition     = alltrue(flatten([for static_route in var.static_routes : contains(["ip-address", "discard", "next-vr", ""], static_route.type)]))
+    error_message = "Valid values type in route are `ip-address` (the default), `discard`, `next-vr`, or an empty string for None"
+  }
+}

--- a/modules/static_routes/versions.tf
+++ b/modules/static_routes/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/tags/README.md
+++ b/modules/tags/README.md
@@ -1,0 +1,112 @@
+Palo Alto Networks PAN-OS Tags Module
+---
+This Terraform module allows users to configure tags.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "tags" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/tags"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group = "test"
+  tags         = {
+    DNS-SRV = {
+      comment = "Tag for DNS servers"
+    }
+    DNS-SRV-2 = {
+      comment = "Tag for DNS servers-2"
+    }
+    "Managed by Terraform" = {
+      comment = "Managed by Terraform"
+    }
+    Outbound = {
+      color   = "Cyan"
+      comment = "Outbound"
+    }
+    Inbound = {
+      color   = "Light Green"
+      comment = "Inbound"
+    }
+    AWS-Route53-Health-Probe = {
+      color = "Gold"
+    }
+    PSN = {
+      color   = "Brown"
+      comment = "PSN"
+    }
+    dns-proxy = {
+      color   = "Olive"
+      comment = "dns-proxy"
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_administrative_tag.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/administrative_tag) | resource |
+| [panos_panorama_administrative_tag.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_administrative_tag) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if _mode_ is panorama, this defines the Device Group for the deployment | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if _mode_ is ngfw, this defines the vsys for the deployment | `string` | `"vsys1"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of the tag objects, where key is the tag object's name:<br>- `color`: (optional) The tag's color. This should either be an empty string (no color) or a string such as `Red`, `Green` etc. (full list of supported colors is available in [provider documentation](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/administrative_tag)).<br>- `comment`: (optional) The description of the administrative tag.<br><br>Example:<pre>tags = {<br>  DNS-SRV = {<br>    comment = "Tag for DNS servers"<br>  }<br>  dns-proxy = {<br>    color   = "Olive"<br>    comment = "dns-proxy"<br>  }<br>}</pre> | <pre>map(object({<br>    color   = optional(string)<br>    comment = optional(string)<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panorama_administrative_tags"></a> [panorama\_administrative\_tags](#output\_panorama\_administrative\_tags) | n/a |
+| <a name="output_panos_administrative_tag"></a> [panos\_administrative\_tag](#output\_panos\_administrative\_tag) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/tags/main.tf
+++ b/modules/tags/main.tf
@@ -1,0 +1,76 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+  tag_color_map = {
+    red            = "color1"
+    green          = "color2"
+    blue           = "color3"
+    yellow         = "color4"
+    copper         = "color5"
+    orange         = "color6"
+    purple         = "color7"
+    gray           = "color8"
+    light_green    = "color9"
+    cyan           = "color10"
+    light_gray     = "color11"
+    blue_gray      = "color12"
+    lime           = "color13"
+    black          = "color14"
+    gold           = "color15"
+    brown          = "color16"
+    olive          = "color17"
+    maroon         = "color19"
+    red_orange     = "color20"
+    yellow_orange  = "color21"
+    forest_green   = "color22"
+    turquoise_blue = "color23"
+    azure_blue     = "color24"
+    cerulean_blue  = "color25"
+    midnight_blue  = "color26"
+    medium_blue    = "color27"
+    cobalt_blue    = "color28"
+    violet_blue    = "color29"
+    blue_violet    = "color30"
+    medium_violet  = "color31"
+    medium_rose    = "color32"
+    lavender       = "color33"
+    orchid         = "color34"
+    thistle        = "color35"
+    peach          = "color36"
+    salmon         = "color37"
+    magenta        = "color38"
+    red_violet     = "color39"
+    mahogany       = "color40"
+    burnt_sienna   = "color41"
+    chestnut       = "color42"
+  }
+}
+
+resource "panos_panorama_administrative_tag" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.tags : {}
+
+  name         = each.key
+  color        = try(local.tag_color_map[lower(replace(each.value.color, " ", "_"))], null)
+  comment      = try(each.value.comment, null)
+  device_group = var.device_group
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_administrative_tag" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? var.tags : {}
+
+  name    = each.key
+  color   = try(local.tag_color_map[lower(replace(each.value.color, " ", "_"))], null)
+  comment = try(each.value.comment, null)
+  vsys    = var.vsys
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/tags/main_test.go
+++ b/modules/tags/main_test.go
@@ -1,0 +1,11 @@
+package tags
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/tags/outputs.tf
+++ b/modules/tags/outputs.tf
@@ -1,0 +1,7 @@
+output "panorama_administrative_tags" {
+  value = panos_panorama_administrative_tag.this
+}
+
+output "panos_administrative_tag" {
+  value = panos_administrative_tag.this
+}

--- a/modules/tags/variables.tf
+++ b/modules/tags/variables.tf
@@ -1,0 +1,46 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "device_group" {
+  description = "Used if _mode_ is panorama, this defines the Device Group for the deployment"
+  default     = "shared"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if _mode_ is ngfw, this defines the vsys for the deployment"
+  default     = "vsys1"
+  type        = string
+}
+
+variable "tags" {
+  description = <<-EOF
+  Map of the tag objects, where key is the tag object's name:
+  - `color`: (optional) The tag's color. This should either be an empty string (no color) or a string such as `Red`, `Green` etc. (full list of supported colors is available in [provider documentation](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/administrative_tag)).
+  - `comment`: (optional) The description of the administrative tag.
+
+  Example:
+  ```
+  tags = {
+    DNS-SRV = {
+      comment = "Tag for DNS servers"
+    }
+    dns-proxy = {
+      color   = "Olive"
+      comment = "dns-proxy"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    color   = optional(string)
+    comment = optional(string)
+  }))
+}

--- a/modules/tags/versions.tf
+++ b/modules/tags/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/template_stacks/README.md
+++ b/modules/template_stacks/README.md
@@ -1,0 +1,84 @@
+Palo Alto Networks PAN-OS Template Stacks Module
+---
+This Terraform module allows users to configure template stacks.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "template_stacks" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/template_stacks"
+
+  mode = "panorama"
+
+  template_stacks = {
+    "test-template-stack" = {
+      description = "My test template stack with devices"
+      templates   = ["test-template"]
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_panorama_template_stack.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_template_stack) | resource |
+| [panos_panorama_template_stack_entry.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_template_stack_entry) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_template_stacks"></a> [template\_stacks](#input\_template\_stacks) | Map of the template stacks, where key is the template stack's name:<br>- `description` - (Optional) The template's description.<br>- `default_vsys` - (Optional) The default virtual system template configuration pushed to firewalls with a single virtual system. Note - you can only set this if there is at least one template in this stack.<br>- `templates` - (Optional) List of templates in this stack.<br>- `devices` - (Optional) List of serial numbers to include in this stack.<br><br>Example:<pre>{<br>  "test-template-stack" = {<br>    description = "My test template stack with devices"<br>    templates   = ["test-template"]<br>    devices     = ["123456789"]<br>  }<br>}</pre> | <pre>map(object({<br>    description  = optional(string)<br>    default_vsys = optional(string)<br>    templates    = optional(list(string))<br>    devices      = optional(list(string), [])<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panorama_template_stacks"></a> [panorama\_template\_stacks](#output\_panorama\_template\_stacks) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/template_stacks/main.tf
+++ b/modules/template_stacks/main.tf
@@ -1,0 +1,32 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+  templates_devices = flatten([for tk, tv in var.template_stacks : [for dv in tv.devices : { template_stack = tk, device = dv }]])
+}
+
+resource "panos_panorama_template_stack" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.template_stacks : {}
+
+  name        = each.key
+  description = each.value.description
+  templates   = each.value.templates
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_template_stack_entry" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? { for td in local.templates_devices : "${td.template_stack}_${td.device}" => td } : {}
+
+  template_stack = each.value.template_stack
+
+  device = each.value.device
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/template_stacks/main_test.go
+++ b/modules/template_stacks/main_test.go
@@ -1,0 +1,11 @@
+package template_stacks
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/template_stacks/outputs.tf
+++ b/modules/template_stacks/outputs.tf
@@ -1,0 +1,3 @@
+output "panorama_template_stacks" {
+  value = panos_panorama_template_stack.this
+}

--- a/modules/template_stacks/variables.tf
+++ b/modules/template_stacks/variables.tf
@@ -1,0 +1,36 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "template_stacks" {
+  description = <<-EOF
+  Map of the template stacks, where key is the template stack's name:
+  - `description` - (Optional) The template's description.
+  - `default_vsys` - (Optional) The default virtual system template configuration pushed to firewalls with a single virtual system. Note - you can only set this if there is at least one template in this stack.
+  - `templates` - (Optional) List of templates in this stack.
+  - `devices` - (Optional) List of serial numbers to include in this stack.
+
+  Example:
+  ```
+  {
+    "test-template-stack" = {
+      description = "My test template stack with devices"
+      templates   = ["test-template"]
+      devices     = ["123456789"]
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    description  = optional(string)
+    default_vsys = optional(string)
+    templates    = optional(list(string))
+    devices      = optional(list(string), [])
+  }))
+}

--- a/modules/template_stacks/versions.tf
+++ b/modules/template_stacks/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/templates/README.md
+++ b/modules/templates/README.md
@@ -1,0 +1,82 @@
+Palo Alto Networks PAN-OS Templates Module
+---
+This Terraform module allows users to configure templates.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "templates" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/templates"
+
+  mode = "panorama"
+
+  templates = {
+    "test-template" = {
+      description = "My test template"
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_panorama_template.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_template) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_templates"></a> [templates](#input\_templates) | Map of the templates, where key is the template's name:<br>- `description` - (Optional) The template's description.<br><br>Example:<pre>{<br>  "test-template" = {<br>    description = "My test template"<br>  }<br>}</pre> | <pre>map(object({<br>    description = optional(string)<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_panorama_templates"></a> [panorama\_templates](#output\_panorama\_templates) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/templates/main.tf
+++ b/modules/templates/main.tf
@@ -1,0 +1,18 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_panorama_template" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? var.templates : {}
+
+  name        = each.key
+  description = each.value.description
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/templates/main_test.go
+++ b/modules/templates/main_test.go
@@ -1,0 +1,11 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/templates/outputs.tf
+++ b/modules/templates/outputs.tf
@@ -1,0 +1,3 @@
+output "panorama_templates" {
+  value = panos_panorama_template.this
+}

--- a/modules/templates/variables.tf
+++ b/modules/templates/variables.tf
@@ -1,0 +1,28 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "templates" {
+  description = <<-EOF
+  Map of the templates, where key is the template's name:
+  - `description` - (Optional) The template's description.
+
+  Example:
+  ```
+  {
+    "test-template" = {
+      description = "My test template"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    description = optional(string)
+  }))
+}

--- a/modules/templates/versions.tf
+++ b/modules/templates/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/virtual_routers/README.md
+++ b/modules/virtual_routers/README.md
@@ -1,0 +1,103 @@
+Palo Alto Networks PAN-OS Virtual Routers Module
+---
+This Terraform module allows users to configure virtual routers.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "virtual_routers" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/virtual_routers"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  template = "test"
+
+  virtual_routers = {
+    "vr" = {
+      static_routes = {
+        custom-ip = {
+          destination = "10.10.20.0/24"
+          next_hop    = "10.10.10.1"
+          type        = "ip-address"
+        }
+        internal-vr = {
+          destination = "10.10.0.0/16"
+          next_hop    = "internal"
+          type        = "next-vr"
+        }
+      }
+    }
+    "external" = {}
+    "internal" = {}
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_panorama_static_route_ipv4.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_static_route_ipv4) | resource |
+| [panos_static_route_ipv4.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/static_route_ipv4) | resource |
+| [panos_virtual_router.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/virtual_router) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_template"></a> [template](#input\_template) | The template name. | `string` | `"default"` | no |
+| <a name="input_template_stack"></a> [template\_stack](#input\_template\_stack) | The template stack name. | `string` | `""` | no |
+| <a name="input_virtual_routers"></a> [virtual\_routers](#input\_virtual\_routers) | Map of the virtual routers, where key is the virtual router's name:<br>- `vsys` - The vsys (default: vsys1)<br>- `interfaces` - List of interfaces that should use this VR. Leave this undefined if the association is managed by `interfaces` module (using `panos_virtual_router_entry` resource).<br>- `static_dist` - (int) Admin distance - Static (default: 10).<br>- `static_ipv6_dist` - (int) Admin distance - Static IPv6 (default: 10).<br>- `ospf_int_dist` - (int) Admin distance - OSPF Int (default: 30).<br>- `ospf_ext_dist` - (int) Admin distance - OSPF Ext (default: 110).<br>- `ospfv3_int_dist` - (int) Admin distance - OSPFv3 Int (default: 30).<br>- `ospfv3_ext_dist` - (int) Admin distance - OSPFv3 Ext (default: 110).<br>- `ibgp_dist` - (int) Admin distance - IBGP (default: 200).<br>- `ebgp_dist` - (int) Admin distance - EBGP (default: 20).<br>- `rip_dist` - (int) Admin distance - RIP (default: 120).<br>- `enable_ecmp` - (bool) Enable ECMP.<br>- `ecmp_max_path` - (int) Maximum number of ECMP paths supported.<br>- `ecmp_symmetric_return` - (bool) Allows return packets to egress out of the ingress interface of the flow.<br>- `ecmp_strict_source_path` - (bool) Force VPN traffic to exit interface that the source-ip belongs to.<br>- `ecmp_load_balance_method` - Load balancing algorithm. Valid values are ip-modulo, ip-hash, weighted-round-robin, or balanced-round-robin.<br>- `ecmp_hash_source_only` - (bool) For ecmp\_load\_balance\_method = ip-hash: Only use source address for hash.<br>- `ecmp_hash_use_port` - (bool) For ecmp\_load\_balance\_method = ip-hash: Use source/destination port for hash.<br>- `ecmp_hash_seed` - (int) For ecmp\_load\_balance\_method = ip-hash: User-specified hash seed.<br>- `ecmp_weighted_round_robin_interfaces` - (Map of ints) For ecmp\_load\_balance\_method = weighted-round-robin: Interface weight used in weighted ECMP load balancing.<br>- `static_routes` - (map(object)) - Map with static routes to create in the VR. Each route supports following settings:<br>  - `destination` - (string) Destination IP address / prefix.<br>  - `interface` - (string) Interface to use.<br>  - `next_hop` - (sting) The value for the type setting.<br>  - `route_table` - (string) Target routing table to install the route. Valid values are unicast (the default), no install, multicast, or both.<br>  - `type` - (string) The next hop type. Valid values are ip-address (the default), discard, next-vr, or an empty string for None.<br>  - `admin_distance` - (int) The admin distance.<br>  - `metric` - (int) Metric value / path cost (default: 10).<br>  - `bfd_profile` - (string) BFD configuration (PAN-OS 7.1+).<br><br>Example:<pre>{<br>  "default" = {}<br>  "vr-with-route" = {<br>    static_routes = {<br>      default = {<br>        destination = "0.0.0.0/0"<br>        next_hop    = "10.0.0.1"<br>        type        = "ip-address"<br>      }<br>    }<br>  }<br>}</pre> | <pre>map(object({<br>    vsys                                 = optional(string, "vsys1")<br>    interfaces                           = optional(list(string))<br>    static_dist                          = optional(number, 10)<br>    static_ipv6_dist                     = optional(number, 10)<br>    ospf_int_dist                        = optional(number, 30)<br>    ospf_ext_dist                        = optional(number, 110)<br>    ospfv3_int_dist                      = optional(number, 30)<br>    ospfv3_ext_dist                      = optional(number, 110)<br>    ibgp_dist                            = optional(number, 200)<br>    ebgp_dist                            = optional(number, 20)<br>    rip_dist                             = optional(number, 120)<br>    enable_ecmp                          = optional(bool)<br>    ecmp_max_path                        = optional(number)<br>    ecmp_symmetric_return                = optional(bool)<br>    ecmp_strict_source_path              = optional(bool)<br>    ecmp_load_balance_method             = optional(string)<br>    ecmp_hash_source_only                = optional(bool)<br>    ecmp_hash_use_port                   = optional(bool)<br>    ecmp_hash_seed                       = optional(number)<br>    ecmp_weighted_round_robin_interfaces = optional(map(number))<br>    static_routes = optional(map(object({<br>      destination    = string<br>      interface      = optional(string)<br>      next_hop       = optional(string)<br>      route_table    = optional(string, "unicast")<br>      type           = optional(string, "ip-address")<br>      admin_distance = optional(number)<br>      metric         = optional(number, 10)<br>      bfd_profile    = optional(string)<br>    })), {})<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_virtual_routers"></a> [virtual\_routers](#output\_virtual\_routers) | n/a |
+| <a name="output_panorama_static_routes_ipv4"></a> [panorama\_static\_routes\_ipv4](#output\_panorama\_static\_routes\_ipv4) | n/a |
+| <a name="output_static_routes_ipv4"></a> [static\_routes\_ipv4](#output\_static\_routes\_ipv4) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/virtual_routers/main.tf
+++ b/modules/virtual_routers/main.tf
@@ -1,0 +1,92 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+  routes = flatten([
+    for vrk, vrv in var.virtual_routers : [
+      for rk, rv in vrv.static_routes : {
+        vr_key    = vrk
+        route_key = rk
+        route_val = rv
+      }
+    ] if can(vrv.static_routes)
+  ])
+}
+
+resource "panos_virtual_router" "this" {
+  for_each = var.virtual_routers
+
+  template       = local.mode_map[var.mode] == 0 ? (var.template_stack == "" ? var.template : null) : null
+  template_stack = local.mode_map[var.mode] == 0 ? var.template_stack == "" ? null : var.template_stack : null
+
+  name                                 = each.key
+  vsys                                 = each.value.vsys
+  interfaces                           = each.value.interfaces
+  static_dist                          = each.value.static_dist
+  static_ipv6_dist                     = each.value.static_ipv6_dist
+  ospf_int_dist                        = each.value.ospf_int_dist
+  ospf_ext_dist                        = each.value.ospf_ext_dist
+  ospfv3_int_dist                      = each.value.ospfv3_int_dist
+  ospfv3_ext_dist                      = each.value.ospfv3_ext_dist
+  ibgp_dist                            = each.value.ibgp_dist
+  ebgp_dist                            = each.value.ebgp_dist
+  rip_dist                             = each.value.rip_dist
+  enable_ecmp                          = each.value.enable_ecmp
+  ecmp_max_path                        = each.value.ecmp_max_path
+  ecmp_symmetric_return                = each.value.ecmp_symmetric_return
+  ecmp_strict_source_path              = each.value.ecmp_strict_source_path
+  ecmp_load_balance_method             = each.value.ecmp_load_balance_method
+  ecmp_hash_source_only                = each.value.ecmp_hash_source_only
+  ecmp_hash_use_port                   = each.value.ecmp_hash_use_port
+  ecmp_hash_seed                       = each.value.ecmp_hash_seed
+  ecmp_weighted_round_robin_interfaces = each.value.ecmp_weighted_round_robin_interfaces
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_panorama_static_route_ipv4" "this" {
+  for_each = local.mode_map[var.mode] == 0 ? { for v in local.routes : "${v.vr_key}-${v.route_key}" => v } : {}
+
+  template       = var.template_stack == "" ? var.template : null
+  template_stack = var.template_stack == "" ? null : var.template_stack
+
+  name           = each.value.route_key
+  virtual_router = panos_virtual_router.this[each.value.vr_key].name
+
+  destination    = each.value.route_val.destination
+  interface      = each.value.route_val.interface
+  next_hop       = each.value.route_val.next_hop
+  route_table    = each.value.route_val.route_table
+  type           = each.value.route_val.type
+  admin_distance = each.value.route_val.admin_distance
+  metric         = each.value.route_val.metric
+  bfd_profile    = each.value.route_val.bfd_profile
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "panos_static_route_ipv4" "this" {
+  for_each = local.mode_map[var.mode] == 1 ? { for v in local.routes : "${v.vr_key}-${v.route_key}" => v } : {}
+
+  name           = each.value.route_key
+  virtual_router = panos_virtual_router.this[each.value.vr_key].name
+
+  destination    = each.value.route_val.destination
+  interface      = each.value.route_val.interface
+  next_hop       = each.value.route_val.next_hop
+  route_table    = each.value.route_val.route_table
+  type           = each.value.route_val.type
+  admin_distance = each.value.route_val.admin_distance
+  metric         = each.value.route_val.metric
+  bfd_profile    = each.value.route_val.bfd_profile
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/virtual_routers/main_test.go
+++ b/modules/virtual_routers/main_test.go
@@ -1,0 +1,11 @@
+package virtual_routers
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/virtual_routers/outputs.tf
+++ b/modules/virtual_routers/outputs.tf
@@ -1,0 +1,11 @@
+output "virtual_routers" {
+  value = panos_virtual_router.this
+}
+
+output "panorama_static_routes_ipv4" {
+  value = panos_panorama_static_route_ipv4.this
+}
+
+output "static_routes_ipv4" {
+  value = panos_static_route_ipv4.this
+}

--- a/modules/virtual_routers/variables.tf
+++ b/modules/virtual_routers/variables.tf
@@ -1,0 +1,133 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "template" {
+  description = "The template name."
+  default     = "default"
+  type        = string
+}
+
+variable "template_stack" {
+  description = "The template stack name."
+  default     = ""
+  type        = string
+}
+
+variable "virtual_routers" {
+  description = <<-EOF
+  Map of the virtual routers, where key is the virtual router's name:
+  - `vsys` - The vsys (default: vsys1)
+  - `interfaces` - List of interfaces that should use this VR. Leave this undefined if the association is managed by `interfaces` module (using `panos_virtual_router_entry` resource).
+  - `static_dist` - (int) Admin distance - Static (default: 10).
+  - `static_ipv6_dist` - (int) Admin distance - Static IPv6 (default: 10).
+  - `ospf_int_dist` - (int) Admin distance - OSPF Int (default: 30).
+  - `ospf_ext_dist` - (int) Admin distance - OSPF Ext (default: 110).
+  - `ospfv3_int_dist` - (int) Admin distance - OSPFv3 Int (default: 30).
+  - `ospfv3_ext_dist` - (int) Admin distance - OSPFv3 Ext (default: 110).
+  - `ibgp_dist` - (int) Admin distance - IBGP (default: 200).
+  - `ebgp_dist` - (int) Admin distance - EBGP (default: 20).
+  - `rip_dist` - (int) Admin distance - RIP (default: 120).
+  - `enable_ecmp` - (bool) Enable ECMP.
+  - `ecmp_max_path` - (int) Maximum number of ECMP paths supported.
+  - `ecmp_symmetric_return` - (bool) Allows return packets to egress out of the ingress interface of the flow.
+  - `ecmp_strict_source_path` - (bool) Force VPN traffic to exit interface that the source-ip belongs to.
+  - `ecmp_load_balance_method` - Load balancing algorithm. Valid values are ip-modulo, ip-hash, weighted-round-robin, or balanced-round-robin.
+  - `ecmp_hash_source_only` - (bool) For ecmp_load_balance_method = ip-hash: Only use source address for hash.
+  - `ecmp_hash_use_port` - (bool) For ecmp_load_balance_method = ip-hash: Use source/destination port for hash.
+  - `ecmp_hash_seed` - (int) For ecmp_load_balance_method = ip-hash: User-specified hash seed.
+  - `ecmp_weighted_round_robin_interfaces` - (Map of ints) For ecmp_load_balance_method = weighted-round-robin: Interface weight used in weighted ECMP load balancing.
+  - `static_routes` - (map(object)) - Map with static routes to create in the VR. Each route supports following settings:
+    - `destination` - (string) Destination IP address / prefix.
+    - `interface` - (string) Interface to use.
+    - `next_hop` - (sting) The value for the type setting.
+    - `route_table` - (string) Target routing table to install the route. Valid values are unicast (the default), no install, multicast, or both.
+    - `type` - (string) The next hop type. Valid values are ip-address (the default), discard, next-vr, or an empty string for None.
+    - `admin_distance` - (int) The admin distance.
+    - `metric` - (int) Metric value / path cost (default: 10).
+    - `bfd_profile` - (string) BFD configuration (PAN-OS 7.1+).
+
+  Example:
+  ```
+  {
+    "default" = {}
+    "vr-with-route" = {
+      static_routes = {
+        default = {
+          destination = "0.0.0.0/0"
+          next_hop    = "10.0.0.1"
+          type        = "ip-address"
+        }
+      }
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    vsys                                 = optional(string, "vsys1")
+    interfaces                           = optional(list(string))
+    static_dist                          = optional(number, 10)
+    static_ipv6_dist                     = optional(number, 10)
+    ospf_int_dist                        = optional(number, 30)
+    ospf_ext_dist                        = optional(number, 110)
+    ospfv3_int_dist                      = optional(number, 30)
+    ospfv3_ext_dist                      = optional(number, 110)
+    ibgp_dist                            = optional(number, 200)
+    ebgp_dist                            = optional(number, 20)
+    rip_dist                             = optional(number, 120)
+    enable_ecmp                          = optional(bool)
+    ecmp_max_path                        = optional(number)
+    ecmp_symmetric_return                = optional(bool)
+    ecmp_strict_source_path              = optional(bool)
+    ecmp_load_balance_method             = optional(string)
+    ecmp_hash_source_only                = optional(bool)
+    ecmp_hash_use_port                   = optional(bool)
+    ecmp_hash_seed                       = optional(number)
+    ecmp_weighted_round_robin_interfaces = optional(map(number))
+    static_routes = optional(map(object({
+      destination    = string
+      interface      = optional(string)
+      next_hop       = optional(string)
+      route_table    = optional(string, "unicast")
+      type           = optional(string, "ip-address")
+      admin_distance = optional(number)
+      metric         = optional(number, 10)
+      bfd_profile    = optional(string)
+    })), {})
+  }))
+
+  validation {
+    condition     = alltrue([for vr in var.virtual_routers : contains(["ip-modulo", "ip-hash", "weighted-round-robin", "balanced-round-robin"], coalesce(vr.ecmp_load_balance_method, "ip-modulo"))])
+    error_message = "Valid types of ECMP load balance method are `ip-modulo`, `ip-hash`, `weighted-round-robin`, or `balanced-round-robin`."
+  }
+  validation {
+    condition = alltrue(flatten([
+      for vr in var.virtual_routers : [
+        for r in vr.static_routes : contains(["unicast", "no install", "multicast", "both"], r.route_table)
+      ]
+    ]))
+    error_message = "Valid values of route's 'route_table' are `unicast` (the default), `no install`, `multicast`, or `both`."
+  }
+  validation {
+    condition = alltrue(flatten([
+      for vr in var.virtual_routers : [
+        for r in vr.static_routes : contains(["ip-address", "discard", "next-vr", ""], r.type)
+      ]
+    ]))
+    error_message = "Valid values of route's 'type' are `ip-address` (the default), `discard`, `next-vr`, or an empty string for None."
+  }
+  validation {
+    condition = alltrue(flatten([
+      for vr in var.virtual_routers : [
+        for r in vr.static_routes : contains(["ip-address", "next-vr"], r.type) ? try(r.next_hop, null) != null : true
+      ]
+    ]))
+    error_message = "Routes of type 'ip-address' and 'next-vr' require 'next_hop' to be set."
+  }
+}

--- a/modules/virtual_routers/versions.tf
+++ b/modules/virtual_routers/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}

--- a/modules/zones/README.md
+++ b/modules/zones/README.md
@@ -1,0 +1,88 @@
+Palo Alto Networks PAN-OS Zones Module
+---
+This Terraform module allows users to configure zones.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "zones" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/zones"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  template = "test"
+  zones = {
+    "Trust-L3" = {
+      mode = "layer3"
+    }
+    "Untrust-L3" = {
+      mode = "layer3"
+    }
+  }
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+---
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_zone.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/zone) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_template"></a> [template](#input\_template) | The template name. | `string` | `"default"` | no |
+| <a name="input_template_stack"></a> [template\_stack](#input\_template\_stack) | The template stack name. | `string` | `""` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Map of the zones, where key is the zone's name:<br>- `vsys` - The vsys (default: vsys1)<br>- `mode` - (Required) The zone's mode. This can be layer3, layer2, virtual-wire, tap, or tunnel.<br>- `zone_profile` - The zone protection profile.<br>- `log_setting` - Log setting.<br>- `enable_user_id` - Boolean to enable user identification.<br>- `interfaces` - List of interfaces to associated with this zone. Leave this undefined if you want to use panos\_zone\_entry resources.<br>- `include_acls` - Users from these addresses/subnets will be identified. This can be an address object, an address group, a single IP address, or an IP address subnet.<br>- `exclude_acls` - Users from these addresses/subnets will not be identified. This can be an address object, an address group, a single IP address, or an IP address subnet.<br><br>Example:<pre>{<br>  "default" = {}<br>}</pre> | <pre>map(object({<br>    vsys           = optional(string, "vsys1")<br>    mode           = optional(string)<br>    zone_profile   = optional(string)<br>    log_setting    = optional(string)<br>    enable_user_id = optional(bool)<br>    interfaces     = optional(list(string))<br>    include_acls   = optional(list(string))<br>    exclude_acls   = optional(list(string))<br>  }))</pre> | `{}` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_zones"></a> [zones](#output\_zones) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zones/main.tf
+++ b/modules/zones/main.tf
@@ -1,0 +1,28 @@
+locals {
+  mode_map = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+}
+
+resource "panos_zone" "this" {
+  for_each = var.zones
+
+  template       = local.mode_map[var.mode] == 0 ? (var.template_stack == "" ? try(var.template, "default") : null) : null
+  template_stack = local.mode_map[var.mode] == 0 ? var.template_stack == "" ? null : var.template_stack : null
+
+  name           = each.key
+  vsys           = each.value.vsys
+  mode           = each.value.mode
+  zone_profile   = each.value.zone_profile
+  log_setting    = each.value.log_setting
+  interfaces     = each.value.interfaces
+  enable_user_id = each.value.enable_user_id
+  include_acls   = each.value.include_acls
+  exclude_acls   = each.value.exclude_acls
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/zones/main_test.go
+++ b/modules/zones/main_test.go
@@ -1,0 +1,11 @@
+package zones
+
+import (
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-modules-vmseries-tests-skeleton/pkg/testskeleton"
+)
+
+func TestValidate(t *testing.T) {
+	testskeleton.ValidateCode(t, nil)
+}

--- a/modules/zones/outputs.tf
+++ b/modules/zones/outputs.tf
@@ -1,0 +1,3 @@
+output "zones" {
+  value = panos_zone.this
+}

--- a/modules/zones/variables.tf
+++ b/modules/zones/variables.tf
@@ -1,0 +1,56 @@
+variable "mode" {
+  description = "The mode to use for the modules. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "template" {
+  description = "The template name."
+  default     = "default"
+  type        = string
+}
+
+variable "template_stack" {
+  description = "The template stack name."
+  default     = ""
+  type        = string
+}
+
+variable "zones" {
+  description = <<-EOF
+  Map of the zones, where key is the zone's name:
+  - `vsys` - The vsys (default: vsys1)
+  - `mode` - (Required) The zone's mode. This can be layer3, layer2, virtual-wire, tap, or tunnel.
+  - `zone_profile` - The zone protection profile.
+  - `log_setting` - Log setting.
+  - `enable_user_id` - Boolean to enable user identification.
+  - `interfaces` - List of interfaces to associated with this zone. Leave this undefined if you want to use panos_zone_entry resources.
+  - `include_acls` - Users from these addresses/subnets will be identified. This can be an address object, an address group, a single IP address, or an IP address subnet.
+  - `exclude_acls` - Users from these addresses/subnets will not be identified. This can be an address object, an address group, a single IP address, or an IP address subnet.
+
+  Example:
+  ```
+  {
+    "default" = {}
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    vsys           = optional(string, "vsys1")
+    mode           = optional(string)
+    zone_profile   = optional(string)
+    log_setting    = optional(string)
+    enable_user_id = optional(bool)
+    interfaces     = optional(list(string))
+    include_acls   = optional(list(string))
+    exclude_acls   = optional(list(string))
+  }))
+  validation {
+    condition     = alltrue([for zone in var.zones : contains(["layer3", "layer2", "virtual-wire", "tap", "tunnel"], zone.mode)])
+    error_message = "Valid types of zone's mode are `layer3`, `layer2`, `virtual-wire`, `tap`, or `tunnel``"
+  }
+}

--- a/modules/zones/versions.tf
+++ b/modules/zones/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}


### PR DESCRIPTION
PS C:\Users\Thomas Lyle\repos\aws_git_hub\aws_deployment\home-lab> terraform plan
panos_vlan_interface.vli: Refreshing state... [id=vsys1:vlan.5]
module.interfaces.panos_ethernet_interface.this["ethernet1/4"]: Refreshing state... [id=vsys1:ethernet1/4]
module.interfaces.panos_ethernet_interface.this["ethernet1/3"]: Refreshing state... [id=vsys1:ethernet1/3]
panos_zone.TEST: Refreshing state... [id=::vsys1:TEST]
panos_layer2_subinterface.example: Refreshing state... [id=aggregate-ethernet:ae4:layer2:vsys1:ae4.5]
module.interfaces.panos_aggregate_interface.this["ae4"]: Refreshing state... [id=vsys1:ae4]
panos_zone_entry.example: Refreshing state... [id=::vsys1:TEST:layer3:vlan.5]
panos_virtual_router_entry.default: Refreshing state... [id=::default:vlan.5]
panos_vlan.vlan5: Refreshing state... [id=vsys1:TEST]
panos_vlan_entry.example: Refreshing state... [id=TEST:ae4.5]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.interfaces.panos_ethernet_interface.this["ethernet1/3"] will be updated in-place
  ~ resource "panos_ethernet_interface" "this" {
        id                              = "vsys1:ethernet1/3"
        name                            = "ethernet1/3"
      ~ vsys                            = "(not vsys1)" -> "vsys1"
        # (27 unchanged attributes hidden)
    }

  # module.interfaces.panos_ethernet_interface.this["ethernet1/4"] will be updated in-place
  ~ resource "panos_ethernet_interface" "this" {
        id                              = "vsys1:ethernet1/4"
        name                            = "ethernet1/4"
      ~ vsys                            = "(not vsys1)" -> "vsys1"
        # (27 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
